### PR TITLE
doc: add link to https://github.com/AlbinLind/dawarich-home-assistant

### DIFF
--- a/docs/tutorials/track-your-location.md
+++ b/docs/tutorials/track-your-location.md
@@ -69,4 +69,5 @@ Content-Type: application/json
 
 There is a way to have your geolocation data from Home Assistant in Dawarich. It might be useful for those who already have Home Assistant and don't want to use another app for tracking.
 
-The guide can be found on Github: [Home Assistant integration](https://github.com/Freika/dawarich/discussions/77#discussioncomment-9904099)
+For a customized integration, follow the guide available on GitHub: [Home Assistant integration](https://github.com/Freika/dawarich/discussions/77#discussioncomment-9904099).
+Alternatively, you can install the HACS integration: [dawarich-home-assistant](https://github.com/AlbinLind/dawarich-home-assistant).


### PR DESCRIPTION
This PR adds a link to the  Home Assistant Community Store (HACS) Integration that I found at https://github.com/AlbinLind/dawarich-home-assistant. 

I hope this change will help other Home Assistant users to integrate even quicker without reading the whole github Issue on how to integrate by using a custom automation.

@Freika, big thanks for such a great self-hosted alternative to Google Location History!