### PR TITLE
Set `z-index` to 0 in StaticMap styles.

### DIFF
--- a/src/components/StaticMap.module.css
+++ b/src/components/StaticMap.module.css
@@ -4,6 +4,7 @@
   border-radius: 12px;
   overflow: hidden;
   cursor: pointer; /* Show pointer cursor to indicate interactivity */
+  z-index: 0;
 }
 
 /* Custom marker styles */


### PR DESCRIPTION
# Fix: Map z-index

Fixed z-index for map component to prevent it from overlapping with the menu bar.