### PR TITLE
Update watcher dir in docs

### DIFF
--- a/docs/tutorials/watcher.md
+++ b/docs/tutorials/watcher.md
@@ -36,6 +36,6 @@ volumes:
 + watched:
 ```
 
-Now, in the container, create a directory for your user (`/tmp/imports/watched/your_user@email.com/`) and put your GPX, Owntracks' `.rec` and GeoJSON files to the directory.
+Now, in the container, create a directory for your user (`/var/app/tmp/imports/watched/your_user@email.com/`) and put your GPX, Owntracks' `.rec` and GeoJSON files to the directory.
 
 Dawarich will automatically import the files and you will receive a notification in the app after the file is imported.


### PR DESCRIPTION
The docs say to put your GPX, Owntracks' `.rec` and GeoJSON files in the /tmp/imports/watched/your_user@email.com/ directory. However the intended directory is really a relative `tmp` path from the `/var/app` directory of the container, and not the literal `/tmp` directory. This PR adds the full `/var/app` path in front to be more explicit.