### PR TITLE
Adjusted restore to docker volume instead of local mount

### DIFF
--- a/docs/tutorials/backup-and-restore.md
+++ b/docs/tutorials/backup-and-restore.md
@@ -16,7 +16,7 @@ docker exec -t dawarich_db pg_dumpall --clean --if-exists --username=postgres | 
 
 ```
 docker compose down -v      # CAUTION! Deletes all Dawarich data to start from scratch.
-# rm -rf DB_DATA_LOCATION   # CAUTION! Deletes all Dawarich data to start from scratch.
+# docker volume rm dawarich_db_data   # CAUTION! Deletes all Dawarich data to start from scratch. Set dawarich_db_data to the correct docker volume name.
 docker compose pull         # Update to latest version of Dawarich (if desired)
 docker compose create       # Create Docker containers for Dawarich apps without running them.
 docker start dawarich_db    # Start Postgres server


### PR DESCRIPTION
Adjusted restore docs to use docker volume rm dawarich_db_data for wiping old DB data. Dawarich uses Docker volumes by default, unlike Immich which relies on local folders.