### PR TITLE
Document Traccar Client setup

### DIFF
--- a/docs/features/tracking-location-history.md
+++ b/docs/features/tracking-location-history.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 1
 title: Tracking Location History
-description: Set up location tracking with the native iOS or Android app, Overland, OwnTracks, or GPSLogger to record and visualize your movements.
+description: Set up location tracking with the native iOS or Android app, Overland, OwnTracks, Traccar, or GPSLogger to record and visualize your movements.
 ---
 
 # Tracking location history
 
-You can set up your own location tracking system using a combination of Dawarich and a mobile app. The primary and recommended way to track your location is through the **native Dawarich iOS and Android apps**, which are designed to work seamlessly with your Dawarich instance. Alternatively, you can use Overland, OwnTracks, or GPSLogger. Refer to [Track your location tutorial](/docs/getting-started/track-your-location) for more information on how to set up your own location tracking system. When a mobile application is set up to send data to Dawarich, you can see your location history on the map, as well as in the form of points and routes.
+You can set up your own location tracking system using a combination of Dawarich and a mobile app. The primary and recommended way to track your location is through the **native Dawarich iOS and Android apps**, which are designed to work seamlessly with your Dawarich instance. Alternatively, you can use Overland, OwnTracks, Traccar Client, or GPSLogger. Refer to [Track your location tutorial](/docs/getting-started/track-your-location) for more information on how to set up your own location tracking system. When a mobile application is set up to send data to Dawarich, you can see your location history on the map, as well as in the form of points and routes.
 
 ![Map](images/map.png)

--- a/docs/getting-started/track-your-location.md
+++ b/docs/getting-started/track-your-location.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 1
 title: Track Your Location
-description: Set up location tracking using the Dawarich app, Overland, OwnTracks, or GPSLogger mobile applications.
+description: Set up location tracking using the Dawarich app, Overland, OwnTracks, Traccar, or GPSLogger mobile applications.
 ---
 
 # Track your location
 
-Dawarich allows you to track your location using [Overland](https://overland.p3k.app/), [OwnTracks](https://owntracks.org/) or [GPSLogger](https://gpslogger.app/) mobile application.
+Dawarich allows you to track your location using [Overland](https://overland.p3k.app/), [OwnTracks](https://owntracks.org/), [Traccar Client](https://www.traccar.org/client/) or [GPSLogger](https://gpslogger.app/) mobile application.
 
 ## API
 
@@ -60,6 +60,20 @@ Dawarich provides an API for tracking your location. You can use the API to send
 6. Paste the following URL: `http://<your-dawarich-instance>/api/v1/owntracks/points?api_key=<your-api-key>`.
 7. Tap on "Back" button (top left corner).
 8. You're all set! OwnTracks will start sending your location data to Dawarich.
+
+## Traccar Client
+
+Dawarich accepts data from [Traccar Client](https://www.traccar.org/client/) (Android and iOS) using its modern JSON protocol (Traccar Client v9.0 or newer).
+
+1. Install Traccar Client on your mobile device.
+2. Open the app and go to settings.
+3. Set the **Server URL** to: `http://<your-dawarich-instance>/api/v1/traccar/points?api_key=<your-api-key>`.
+4. Pick a **Device Identifier** — this is stored on the point as `tracker_id`, useful if you push from multiple devices to one account.
+5. Enable the service. Traccar Client will start sending your location to Dawarich.
+
+:::note
+Dawarich only supports the JSON payload sent by Traccar Client v9+. The legacy OsmAnd query-string protocol used by older clients and some third-party trackers is not supported on this endpoint — use the OwnTracks endpoint with those instead.
+:::
 
 ## GPS Logger
 


### PR DESCRIPTION
## Summary
- Adds a Traccar Client section to the "Track your location" tutorial covering server URL, device identifier, and the JSON-only support note.
- Mentions Traccar Client alongside Overland, OwnTracks, and GPSLogger in the tracking feature page and front-matter descriptions.

## Test plan
- [ ] `npm run build` passes locally.
- [ ] Spot-check rendered pages: `/docs/getting-started/track-your-location` and `/docs/features/tracking-location-history`.