### PR TITLE
Update stale seed password references to safepassword

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ yarn-error.log*
 
 .playwright-mcp/
 .playwright-cli/
+
+# Worktrees
+.worktrees/

--- a/docs/self-hosting/installation/synology.md
+++ b/docs/self-hosting/installation/synology.md
@@ -142,4 +142,4 @@ The container should run and finish automatically.
 
 ## Default credentials
 
-The default credentials are `demo@dawarich.app` and `password`.
+The default credentials are `demo@dawarich.app` and `safepassword`.

--- a/docs/self-hosting/introduction.md
+++ b/docs/self-hosting/introduction.md
@@ -34,7 +34,7 @@ You can use our [Hetzner](https://hetzner.cloud/?ref=DQC5djwEU64f) and [DigitalO
 docker compose up -d
 ```
 
-4. You're all set! Visit your Dawarich instance at `http://localhost:3000` or `http://<your-server-ip>:3000`. The default credentials are `demo@dawarich.app` and `password`
+4. You're all set! Visit your Dawarich instance at `http://localhost:3000` or `http://<your-server-ip>:3000`. The default credentials are `demo@dawarich.app` and `safepassword`
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/j6xNtSNzrwQ?si=9VFoYMdFl2jSTGWr" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 


### PR DESCRIPTION
## Summary

Companion to [Freika/dawarich#2636](https://github.com/Freika/dawarich/issues/2636). Updates the public self-hosting docs to use `safepassword` in place of the old `password` default that no longer matches the seed script.

## Changes

- `docs/self-hosting/installation/synology.md`
- `docs/self-hosting/introduction.md`

Pure text edit. Companion app PR (`fix/seed-password-doc-drift` in `Freika/dawarich`) cleans up the same drift in the app repo's docs.

## Test plan

- [ ] No remaining references to the old `password` seed default in the public docs

Closes Freika/dawarich#2636 (docs portion)