### PR TITLE
Document SMTP env vars and add SMTP configuration page

### DIFF
--- a/docs/self-hosting/configuration/smtp.md
+++ b/docs/self-hosting/configuration/smtp.md
@@ -1,0 +1,114 @@
+---
+sidebar_position: 9
+title: Configuring SMTP
+description: Configure outgoing email (password reset, digests, family invitations) for your self-hosted Dawarich instance, including Office 365 and other providers that need login authentication or longer timeouts.
+---
+
+# Configuring SMTP
+
+Dawarich sends outgoing email for password resets, year-end digests, and family invitations. Configure your SMTP server with the environment variables below. Set them on **both** `dawarich_app` and `dawarich_sidekiq` — the Sidekiq container is what actually delivers the messages.
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `DOMAIN` | _(required)_ | Public hostname used to build links in emails. No protocol, no trailing slash. Example: `dawarich.example.com`. |
+| `SMTP_SERVER` | _(required)_ | SMTP server hostname. Example: `smtp.office365.com`, `smtp.gmail.com`, `mail.privateemail.com`. |
+| `SMTP_PORT` | _(required)_ | SMTP port. Typically `587` for STARTTLS, `465` for SMTPS, `25` for unauthenticated relays. |
+| `SMTP_DOMAIN` | _(optional)_ | HELO/EHLO domain used at SMTP handshake. For transactional relays (Brevo, Mailgun, SendGrid, Postmark, Resend), set this to your **verified sender domain** — typically the part after `@` in `SMTP_FROM`. The relay cross-checks HELO/EHLO against the verified domain for DKIM/SPF alignment, and a mismatch hurts deliverability. Permissive relays (local Postfix, internal MTAs) often ignore this. |
+| `SMTP_USERNAME` | _(optional)_ | SMTP username. Leave unset for unauthenticated relays. |
+| `SMTP_PASSWORD` | _(optional)_ | SMTP password. Leave unset for unauthenticated relays. |
+| `SMTP_FROM` | _(required)_ | "From" address on outgoing email. Example: `dawarich@example.com`. |
+| `SMTP_AUTHENTICATION` | `plain` | Auth mechanism. The common values are `plain`, `login` (Office 365 / Microsoft 365 requires this), and `cram_md5`. `digest_md5`, `gssapi`, `ntlm`, and `xoauth2` are also accepted by the underlying Net::SMTP driver but are rarely useful for self-hosted Dawarich — choose one of the first three unless you know you need an enterprise mechanism. |
+| `SMTP_STARTTLS` | `true` | Opportunistic TLS upgrade on port 587. Leave `true` for any internet-facing relay (Brevo, Gmail, Office 365, etc.) so credentials and message bodies are encrypted in transit. Set to `false` only for plain SMTP on port 25 to a trusted local relay (LAN Postfix, internal MTA). On port 465 (SMTPS / implicit TLS) this setting has no effect — the connection is TLS from byte one. |
+| `SMTP_OPEN_TIMEOUT` | `5` | Seconds to wait for the TCP connection. Bump to `25` for slow providers (Office 365, Gmail). |
+| `SMTP_READ_TIMEOUT` | `5` | Seconds to wait for a response after a command is sent. Bump to `25` for slow providers. |
+
+## Email link protocol
+
+The protocol used in links inside outgoing emails (password reset, family invite, digest) is **hardcoded to `https://`** since Dawarich 1.7.6. This is deliberate: nearly all self-hosted instances sit behind a reverse proxy with a real TLS certificate, and the previous setup tied the email protocol to `APPLICATION_PROTOCOL`, which broke reverse-proxy deployments that legitimately need `APPLICATION_PROTOCOL=http`.
+
+If you genuinely serve Dawarich over plain HTTP (LAN-only, Tailscale-only, or another private network without TLS) and want emails to link with `http://`, mount a one-line initializer:
+
+```ruby
+# config/initializers/mailer_protocol.rb
+Rails.application.config.action_mailer.default_url_options[:protocol] = 'http'
+```
+
+This is the only supported way to override the email link protocol.
+
+## Common providers
+
+### Office 365 / Microsoft 365
+
+```yaml
+DOMAIN: "dawarich.example.com"
+SMTP_SERVER: "smtp.office365.com"
+SMTP_PORT: "587"
+SMTP_USERNAME: "dawarich@example.com"
+SMTP_PASSWORD: "<app-password>"
+SMTP_FROM: "dawarich@example.com"
+SMTP_AUTHENTICATION: "login"
+SMTP_STARTTLS: "true"
+SMTP_OPEN_TIMEOUT: "25"
+SMTP_READ_TIMEOUT: "25"
+```
+
+Office 365 rejects `plain` authentication and frequently times out within 5 seconds. Use `login` and longer timeouts.
+
+### Gmail (with app password)
+
+```yaml
+DOMAIN: "dawarich.example.com"
+SMTP_SERVER: "smtp.gmail.com"
+SMTP_PORT: "587"
+SMTP_USERNAME: "you@gmail.com"
+SMTP_PASSWORD: "<16-char-app-password>"
+SMTP_FROM: "you@gmail.com"
+SMTP_AUTHENTICATION: "plain"
+SMTP_STARTTLS: "true"
+```
+
+Generate an app-specific password at [myaccount.google.com/apppasswords](https://myaccount.google.com/apppasswords) — your normal Google password will not work.
+
+### Local Postfix / unauthenticated relay
+
+```yaml
+DOMAIN: "dawarich.example.com"
+SMTP_SERVER: "192.168.1.10"
+SMTP_PORT: "25"
+SMTP_FROM: "dawarich@example.com"
+SMTP_STARTTLS: "false"
+```
+
+Leave `SMTP_USERNAME`, `SMTP_PASSWORD`, and `SMTP_AUTHENTICATION` unset.
+
+## Testing the configuration
+
+After updating your compose file, recreate both services:
+
+```bash
+docker compose up -d --force-recreate dawarich_app dawarich_sidekiq
+```
+
+Then trigger a password-reset email from the login page (or use the Rails console) and watch the Sidekiq logs:
+
+```bash
+docker compose logs -f dawarich_sidekiq | grep -i mail
+```
+
+A successful delivery logs `Sent mail to ... (NNNms)`. A failure logs the SMTP error verbatim — most commonly:
+
+| Symptom | Likely cause |
+|---|---|
+| `Net::ReadTimeout` | Bump `SMTP_OPEN_TIMEOUT` and `SMTP_READ_TIMEOUT` to `25`. |
+| `535 5.7.3 Authentication unsuccessful` | Wrong `SMTP_AUTHENTICATION` (try `login`) or wrong credentials. |
+| `Missing host to link to!` | `DOMAIN` is unset on `dawarich_app`. |
+| Email delivers but link is `http://...:3000/...` | You're on Dawarich `< 1.7.6`. Upgrade — the email link protocol is now hardcoded to `https://` (see "Email link protocol" above). |
+| Sidekiq job succeeds but no email arrives | Wrong server in `SMTP_SERVER`, or the relay is silently dropping mail. Check the relay's logs, not Dawarich's. |
+
+## What changed in 1.7.6
+
+Prior to this release, `SMTP_AUTHENTICATION`, `SMTP_OPEN_TIMEOUT`, and `SMTP_READ_TIMEOUT` were hardcoded in `config/environments/production.rb` and required mounting a custom Rails initializer to override. They are now first-class environment variables.
+
+The email link protocol was also previously coupled to `APPLICATION_PROTOCOL`, which caused reverse-proxy deployments (where `APPLICATION_PROTOCOL=http` is required to avoid SSL redirect loops) to send password-reset emails with `http://` links to the public HTTPS site. The two are now decoupled: `APPLICATION_PROTOCOL` only controls `config.force_ssl`, and the email link protocol is hardcoded to `https://`. Plain-HTTP self-hosters can override with a one-line initializer (see "Email link protocol" above).

--- a/docs/self-hosting/environment-variables.md
+++ b/docs/self-hosting/environment-variables.md
@@ -8,7 +8,7 @@ description: Reference for all Dawarich environment variables including database
 
 ## Environment Variables
 
-As many other applications, Dawarich uses environment variables to configure its behavior. The following environment variables are supported:
+As many other applications, Dawarich uses environment variables to configure its behavior. The default `docker-compose.yml` file provides defaults that are good enough to deploy the app and start using it. The following environment variables are supported:
 
 ### Core Settings
 

--- a/docs/self-hosting/environment-variables.md
+++ b/docs/self-hosting/environment-variables.md
@@ -93,19 +93,31 @@ If your identity provider doesn't support OIDC discovery, use these instead of `
 
 ### Email (SMTP)
 
+:::tip Full guide
+
+See [Configuring SMTP](./configuration/smtp.md) for provider-specific examples (Office 365, Gmail, Brevo, local Postfix), the email link protocol behavior, and a troubleshooting matrix.
+
+:::
+
 | Environment Variable | Default Value | Description |
 | -------------------- | ------------- | ----------- |
 | `SMTP_SERVER` | `nil` | Your SMTP server hostname |
 | `SMTP_PORT` | `nil` | Your SMTP port (typically 587 for TLS) |
-| `SMTP_DOMAIN` | `nil` | Your SMTP domain |
+| `SMTP_DOMAIN` | `nil` | HELO/EHLO domain. For transactional relays (Brevo, Mailgun, SendGrid, Postmark, Resend), set this to your verified sender domain — typically the part after `@` in `SMTP_FROM`. |
 | `SMTP_USERNAME` | `nil` | Your SMTP username |
 | `SMTP_PASSWORD` | `nil` | Your SMTP password |
 | `SMTP_FROM` | `nil` | Email address to send emails from |
+| `SMTP_AUTHENTICATION` | `plain` | Auth mechanism. Common values: `plain`, `login` (Office 365 / Microsoft 365 requires this), `cram_md5`. `digest_md5`, `gssapi`, `ntlm`, `xoauth2` also accepted but rarely useful. |
+| `SMTP_STARTTLS` | `true` | Opportunistic TLS upgrade on port 587. Leave `true` for internet-facing relays. Set `false` only for plain SMTP on port 25 to a trusted local relay. No effect on port 465 (SMTPS / implicit TLS). |
+| `SMTP_OPEN_TIMEOUT` | `5` | Seconds to wait for the TCP connection. Bump to `25` for slow providers. |
+| `SMTP_READ_TIMEOUT` | `5` | Seconds to wait for an SMTP response. Bump to `25` for slow providers. |
 
 Email is required for:
 - Password reset
 - Year-end digest emails
 - Family invitation emails
+
+Email links are sent as `https://` regardless of `APPLICATION_PROTOCOL`. Plain-HTTP self-hosters need a one-line initializer override — see [Configuring SMTP → Email link protocol](./configuration/smtp.md#email-link-protocol).
 
 ### Prometheus Monitoring
 

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -251,6 +251,50 @@ Source URL: https://dawarich.app/docs/self-hosting/introduction/
 
 ---
 
+## Configuring outgoing email (SMTP)
+
+Dawarich sends outgoing email for password resets, year-end digests, and family invitations. SMTP is configured entirely via environment variables — set them on **both** `dawarich_app` and `dawarich_sidekiq` containers (Sidekiq is what actually delivers the messages).
+
+### Required variables
+
+- `DOMAIN` — public hostname used to build links in emails (no protocol, no trailing slash). Example: `dawarich.example.com`.
+- `SMTP_SERVER` — SMTP server hostname. Example: `smtp.office365.com`, `smtp.gmail.com`.
+- `SMTP_PORT` — typically `587` (STARTTLS), `465` (SMTPS), or `25` (unauthenticated relay).
+- `SMTP_FROM` — "From" address on outgoing email.
+
+### Optional variables
+
+- `SMTP_USERNAME`, `SMTP_PASSWORD` — leave unset for unauthenticated local relays.
+- `SMTP_DOMAIN` — HELO/EHLO domain. For transactional relays (Brevo, Mailgun, SendGrid, Postmark, Resend), set to your verified sender domain — typically the part after `@` in `SMTP_FROM`. The relay cross-checks HELO/EHLO against the verified domain for DKIM/SPF alignment.
+- `SMTP_AUTHENTICATION` (default `plain`) — `plain`, `login` (Office 365 / Microsoft 365), or `cram_md5` are the common values. `digest_md5`, `gssapi`, `ntlm`, and `xoauth2` are also accepted but rarely useful.
+- `SMTP_STARTTLS` (default `true`) — opportunistic TLS upgrade on port 587. Leave `true` for internet-facing relays so credentials and message bodies are encrypted. Set `false` only for plain SMTP on port 25 to a trusted local relay. No effect on port 465 (SMTPS / implicit TLS — connection is TLS from byte one).
+- `SMTP_OPEN_TIMEOUT` (default `5`) and `SMTP_READ_TIMEOUT` (default `5`) — bump to `25` for slow providers (Office 365, Gmail).
+
+### Email link protocol
+
+The protocol used in links inside outgoing emails is hardcoded to `https://` since Dawarich 1.7.6. `APPLICATION_PROTOCOL` controls `config.force_ssl`, NOT the email link protocol — these were intentionally decoupled because reverse-proxy deployments need `APPLICATION_PROTOCOL=http` to avoid SSL redirect loops, but emails should still link to the public HTTPS site. Plain-HTTP self-hosters (LAN, Tailscale) can override the email protocol with a one-line `config/initializers/mailer_protocol.rb` setting `default_url_options[:protocol] = 'http'`.
+
+### Example: Office 365 / Microsoft 365
+
+```yaml
+DOMAIN: "dawarich.example.com"
+SMTP_SERVER: "smtp.office365.com"
+SMTP_PORT: "587"
+SMTP_USERNAME: "dawarich@example.com"
+SMTP_PASSWORD: "<app-password>"
+SMTP_FROM: "dawarich@example.com"
+SMTP_AUTHENTICATION: "login"
+SMTP_STARTTLS: "true"
+SMTP_OPEN_TIMEOUT: "25"
+SMTP_READ_TIMEOUT: "25"
+```
+
+Office 365 rejects `plain` authentication and frequently times out within the default 5 seconds.
+
+Source URL: https://dawarich.app/docs/self-hosting/configuration/smtp/
+
+---
+
 ## Top FAQ entries (self-hosting & admin)
 
 ### How to enter the Dawarich console

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -47,6 +47,7 @@ The expanded version of the most-cited pages is at [/llms-full.txt](https://dawa
 - [Docker compose install](https://dawarich.app/docs/self-hosting/installation/docker-compose/): Recommended install path.
 - [Hardware requirements](https://dawarich.app/docs/self-hosting/hardware-requirements/): Sizing guide by data volume.
 - [Environment variables](https://dawarich.app/docs/self-hosting/environment-variables): All configuration knobs.
+- [Configuring SMTP](https://dawarich.app/docs/self-hosting/configuration/smtp/): Outgoing email setup (password resets, digests, family invites); Office 365 / Gmail / local relay examples; mailer-protocol decoupling in 1.7.6.
 - [Backup & restore](https://dawarich.app/docs/self-hosting/maintenance/backup-and-restore/): Postgres backup procedures.
 - [Updating](https://dawarich.app/docs/self-hosting/updating/): `docker compose pull && docker compose up -d`.
 - [API reference](https://dawarich.app/docs/api/dawarich-api/): Full REST API, auth via API key, push points, query history.


### PR DESCRIPTION
## Summary

Companion to [Freika/dawarich#1469](https://github.com/Freika/dawarich/issues/1469). Documents the new env-var-driven SMTP configuration shipping in the app repo.

## Changes

- `docs/self-hosting/configuration/smtp.md` (new) — full SMTP setup page covering Gmail, custom SMTP, STARTTLS, and OpenSSL verify modes
- `docs/self-hosting/environment-variables.md` — new `SMTP_*` env vars added to the reference list

## Test plan

- [ ] `npm run build` passes
- [ ] New SMTP page renders and links from the self-hosting nav
- [ ] Companion app PR ships in lockstep

Closes Freika/dawarich#1469 (docs portion)