### PR TITLE
docs: document OIDC_PKCE_ENABLED env var

### DIFF
--- a/docs/self-hosting/configuration/oidc-authentication.md
+++ b/docs/self-hosting/configuration/oidc-authentication.md
@@ -43,6 +43,7 @@ Configure the following environment variables in your `docker-compose.yml` file 
 |----------|---------|-------------|
 | `OIDC_PROVIDER_NAME` | `Openid Connect` | Custom display name for the login button |
 | `OIDC_AUTO_REGISTER` | `true` | Automatically create accounts for new OIDC users |
+| `OIDC_PKCE_ENABLED` | `false` | Enable PKCE (S256) for the authorization code flow. Required when your OIDC client enforces PKCE (e.g. Pocket ID, hardened Authentik/Keycloak) |
 | `ALLOW_EMAIL_PASSWORD_REGISTRATION` | `false` | Allow traditional email/password registration and signing in alongside OIDC |
 
 ### Manual Endpoint Configuration (Alternative to Discovery)

--- a/docs/self-hosting/environment-variables.md
+++ b/docs/self-hosting/environment-variables.md
@@ -76,6 +76,7 @@ For detailed setup instructions, see the [OIDC Authentication Tutorial](/docs/se
 | `OIDC_REDIRECT_URI` | Auto-generated | Callback URL. Defaults to `{APPLICATION_URL}/users/auth/openid_connect/callback` |
 | `OIDC_PROVIDER_NAME` | `Openid Connect` | Custom display name for the OIDC login button |
 | `OIDC_AUTO_REGISTER` | `true` | Automatically create accounts for new OIDC users |
+| `OIDC_PKCE_ENABLED` | `false` | Enable PKCE (S256) for the authorization code flow. Required when your OIDC client enforces PKCE (e.g. Pocket ID, hardened Authentik/Keycloak) |
 | `ALLOW_EMAIL_PASSWORD_REGISTRATION` | `false` | Allow traditional email/password registration alongside OIDC |
 
 #### Manual OIDC Configuration (Alternative to Discovery)


### PR DESCRIPTION
## Summary

Adds the new `OIDC_PKCE_ENABLED` toggle (default `false`) to both OIDC documentation pages so self-hosters configuring Pocket ID or hardened Authentik/Keycloak know it exists.

- `docs/self-hosting/environment-variables.md` — added row in the OIDC table
- `docs/self-hosting/configuration/oidc-authentication.md` — added row in the Optional Variables table

Companion to [Freika/dawarich#2753](https://github.com/Freika/dawarich/pull/2753) (fixes [Freika/dawarich#2282](https://github.com/Freika/dawarich/issues/2282) — Pocket ID + PKCE sign-in failure).

## Test plan

- [ ] `npm run build` succeeds locally
- [ ] Both OIDC tables render the new row correctly in dev preview
- [ ] Merge order: this PR should land alongside or after Freika/dawarich#2753 so the docs don't reference an env var that isn't shipped yet