### PR TITLE
feat: family plan — pricing page & docs

### DIFF
--- a/docs/features/family-plan.md
+++ b/docs/features/family-plan.md
@@ -1,0 +1,53 @@
+---
+sidebar_position: 15
+title: Family Plan
+description: One annual Dawarich Cloud subscription that gives full Pro access to you and up to four invited members — five seats in total.
+---
+
+# Family Plan
+
+The **Family plan** is a single annual Dawarich Cloud subscription that covers a whole household. One person pays, and full Pro-level access is shared with up to four invited members — **five seats in total**.
+
+:::info
+The Family plan is sold as an **annual subscription only**, like the Lite plan. There is no monthly option.
+:::
+
+## What you get
+
+- **Five seats on one subscription** — the owner plus up to four invited members.
+- **Full Pro access for everyone** — every member gets the complete Pro feature set: unlimited history, heatmap and Fog of War layers, the 3D globe view, photo integrations, the full Write API, and the higher API rate limit.
+- **Real-time family location sharing** — see each other on the map, with each member controlling their own sharing. See [Family Location Sharing](/docs/features/family) for how sharing works.
+
+## How seats work
+
+The person who buys the Family plan becomes the **owner** of the family group. The owner creates the family and sends invitations; invited people join without buying their own subscription.
+
+- Only a user on the Family plan can **create and own** a family on Dawarich Cloud.
+- Invited members do **not** need their own plan — they inherit full access for as long as they are part of the family.
+- A family can have **up to five members in total**, including pending invitations.
+
+To create a family and invite people, see [Family Location Sharing → Creating a Family](/docs/features/family#creating-a-family).
+
+## Members inherit access while in the family
+
+Member access is **derived from family membership**, computed every time Dawarich checks what a member can do:
+
+- The moment someone **accepts an invitation**, they gain full Pro access — nothing is billed to them, and there is no separate upgrade step.
+- If a member **leaves** the family, or the owner **removes** them, their access reverts to their own plan automatically.
+- If the **owner cancels or downgrades** the Family subscription, every member reverts to their own plan.
+
+Access changes take effect immediately because they are evaluated at read time — there is no nightly sync or per-member billing.
+
+## Your data is always yours
+
+Losing Family access never deletes anyone's data. When a member leaves the family or the owner's subscription ends, that member's location history is still intact — it is only filtered to the limits of their own plan. Exports always return everything, on every plan.
+
+## Pricing
+
+The Family plan is billed annually. See the [pricing page](/pricing) for the current price.
+
+<!-- TODO: set Family annual price before launch -->
+
+## Self-hosting
+
+Self-hosted Dawarich includes every feature for free, with no member limit on families. The Family plan applies to **Dawarich Cloud** only.

--- a/docs/features/family.md
+++ b/docs/features/family.md
@@ -9,7 +9,7 @@ description: Share your real-time location with trusted family members and frien
 The Family feature allows you to share your real-time location with trusted family members and friends. This enables you to see each other's locations on the map while maintaining full control over your privacy.
 
 :::info
-The Family feature is currently only available for self-hosted instances of Dawarich.
+On self-hosted instances, the Family feature is available for free with no member limit. On Dawarich Cloud, creating a family requires the [Family plan](/docs/features/family-plan), which covers up to five members on one annual subscription.
 :::
 
 ## Overview

--- a/src/components/PricingCard.js
+++ b/src/components/PricingCard.js
@@ -7,6 +7,8 @@ export default function PricingCard({
 	title = "Annual Subscription",
 	annualPrice = 120,
 	monthlyPrice = null,
+	priceLabel = null,
+	priceSuffix = "/yr",
 	description = "Full access to all features.",
 	perDayText = null,
 	features = [],
@@ -37,20 +39,30 @@ export default function PricingCard({
 			{badge && <div className={styles.planBadge}>{badge}</div>}
 			<h2 className={styles.title}>{title}</h2>
 
-			<div className={styles.priceContainer}>
-				<div className={styles.mainPrice}>
-					<span className={styles.currency}>&euro;</span>
-					<span className={styles.currentPrice}>{displayPrice}</span>
-					<span className={styles.period}>/{displayPeriod}</span>
-				</div>
-				{(isAnnual || !hasMonthly) && (
-					<div className={styles.equivalentPrice}>
-						&euro;{monthlyEquivalent}/month
+			{priceLabel ? (
+				<div className={styles.priceContainer}>
+					<div className={styles.mainPrice}>
+						{/* TODO: set Family annual price before launch */}
+						<span className={styles.currentPrice}>{priceLabel}</span>
+						<span className={styles.period}>{priceSuffix}</span>
 					</div>
-				)}
-			</div>
+				</div>
+			) : (
+				<div className={styles.priceContainer}>
+					<div className={styles.mainPrice}>
+						<span className={styles.currency}>&euro;</span>
+						<span className={styles.currentPrice}>{displayPrice}</span>
+						<span className={styles.period}>/{displayPeriod}</span>
+					</div>
+					{(isAnnual || !hasMonthly) && (
+						<div className={styles.equivalentPrice}>
+							&euro;{monthlyEquivalent}/month
+						</div>
+					)}
+				</div>
+			)}
 
-			{hasMonthly && (
+			{!priceLabel && hasMonthly && (
 				<div className={styles.toggleContainer}>
 					<div className={styles.toggleTrack}>
 						<button

--- a/src/components/PricingSection.js
+++ b/src/components/PricingSection.js
@@ -68,6 +68,29 @@ export default function PricingSection() {
 							trialText="Cancel anytime"
 						/>
 					</div>
+
+					<div className={styles.cardWrapper}>
+						<PricingCard
+							title="Family"
+							priceLabel="€TBD"
+							priceSuffix="/yr"
+							description="Every Pro feature for the whole household — one annual subscription, up to 5 people."
+							perDayText={false}
+							includesLabel="Everything in Pro, plus:"
+							features={[]}
+							proOnlyFeatures={[
+								"Up to 5 members on one subscription",
+								"Each member gets full Pro access",
+								"Invite or remove members anytime",
+								"Members inherit access while in the family",
+								"Real-time family location sharing",
+							]}
+							buttonText="Notify Me"
+							buttonVariant="secondary"
+							buttonLink="https://my.dawarich.app/users/sign_up?utm_source=site&utm_medium=pricing&utm_campaign=family&plan=family"
+							trialText="Annual only · Cancel anytime"
+						/>
+					</div>
 				</div>
 
 				<div className={styles.guarantee}>

--- a/src/data/pricingOffers.js
+++ b/src/data/pricingOffers.js
@@ -1,0 +1,38 @@
+export const pricingOffers = [
+	{
+		"@type": "Offer",
+		name: "Lite (annual)",
+		price: "49.99",
+		priceCurrency: "EUR",
+		url: "https://dawarich.app/pricing/",
+	},
+	{
+		"@type": "Offer",
+		name: "Pro (monthly)",
+		price: "17.99",
+		priceCurrency: "EUR",
+		url: "https://dawarich.app/pricing/",
+	},
+	{
+		"@type": "Offer",
+		name: "Pro (annual)",
+		price: "119.99",
+		priceCurrency: "EUR",
+		url: "https://dawarich.app/pricing/",
+	},
+	{
+		"@type": "Offer",
+		// TODO: set Family annual price before launch
+		name: "Family (annual)",
+		price: "TBD",
+		priceCurrency: "EUR",
+		url: "https://dawarich.app/pricing/",
+	},
+	{
+		"@type": "Offer",
+		name: "Self-hosted",
+		price: "0",
+		priceCurrency: "EUR",
+		url: "https://dawarich.app/docs/self-hosting/introduction",
+	},
+];

--- a/src/data/pricingOffers.test.js
+++ b/src/data/pricingOffers.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { pricingOffers } from "./pricingOffers";
+
+describe("pricingOffers", () => {
+	it("should include a Family annual offer", () => {
+		const family = pricingOffers.find((o) => o.name === "Family (annual)");
+		expect(family).toBeDefined();
+		expect(family.priceCurrency).toBe("EUR");
+		expect(family["@type"]).toBe("Offer");
+	});
+
+	it("should keep the existing Lite, Pro and Self-hosted offers", () => {
+		const names = pricingOffers.map((o) => o.name);
+		expect(names).toContain("Lite (annual)");
+		expect(names).toContain("Pro (monthly)");
+		expect(names).toContain("Pro (annual)");
+		expect(names).toContain("Self-hosted");
+	});
+
+	it("should mark the Family price as TBD until launch", () => {
+		const family = pricingOffers.find((o) => o.name === "Family (annual)");
+		expect(family.price).toBe("TBD");
+	});
+});

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -4,6 +4,7 @@ import Layout from "@theme/Layout";
 import { initializePaddle } from "@paddle/paddle-js";
 import PricingSection from "@site/src/components/PricingSection";
 import FAQ from "@site/src/components/FAQ";
+import { pricingOffers } from "@site/src/data/pricingOffers";
 
 export default function PricingPage() {
 	useEffect(() => {
@@ -15,7 +16,7 @@ export default function PricingPage() {
 	return (
 		<Layout
 			title="Pricing — Dawarich"
-			description="Simple pricing for Dawarich Cloud. Lite €49.99/yr or Pro €17.99/mo. 7-day free trial, 14-day risk-free refund, cancel anytime. Or self-host for free."
+			description="Simple pricing for Dawarich Cloud. Lite €49.99/yr, Pro €17.99/mo, or Family for up to 5 members. 7-day free trial, 14-day risk-free refund, cancel anytime. Or self-host for free."
 		>
 			<Head>
 				<meta property="og:type" content="website" />
@@ -23,7 +24,7 @@ export default function PricingPage() {
 				<meta property="og:title" content="Pricing — Dawarich" />
 				<meta
 					property="og:description"
-					content="Lite €49.99/yr or Pro €17.99/mo. 7-day free trial, 14-day risk-free refund. Or self-host for free."
+					content="Lite €49.99/yr, Pro €17.99/mo, or Family for up to 5 members. 7-day free trial, 14-day risk-free refund. Or self-host for free."
 				/>
 				<meta
 					property="og:image"
@@ -33,7 +34,7 @@ export default function PricingPage() {
 				<meta name="twitter:title" content="Pricing — Dawarich" />
 				<meta
 					name="twitter:description"
-					content="Lite €49.99/yr or Pro €17.99/mo. 7-day free trial, 14-day risk-free refund. Or self-host for free."
+					content="Lite €49.99/yr, Pro €17.99/mo, or Family for up to 5 members. 7-day free trial, 14-day risk-free refund. Or self-host for free."
 				/>
 				<meta
 					name="twitter:image"
@@ -49,36 +50,7 @@ export default function PricingPage() {
 						description:
 							"Privacy-first alternative to Google Timeline. Hosted in Europe. Self-hostable, open source.",
 						brand: { "@type": "Brand", name: "Dawarich" },
-						offers: [
-							{
-								"@type": "Offer",
-								name: "Lite (annual)",
-								price: "49.99",
-								priceCurrency: "EUR",
-								url: "https://dawarich.app/pricing/",
-							},
-							{
-								"@type": "Offer",
-								name: "Pro (monthly)",
-								price: "17.99",
-								priceCurrency: "EUR",
-								url: "https://dawarich.app/pricing/",
-							},
-							{
-								"@type": "Offer",
-								name: "Pro (annual)",
-								price: "119.99",
-								priceCurrency: "EUR",
-								url: "https://dawarich.app/pricing/",
-							},
-							{
-								"@type": "Offer",
-								name: "Self-hosted",
-								price: "0",
-								priceCurrency: "EUR",
-								url: "https://dawarich.app/docs/self-hosting/introduction",
-							},
-						],
+						offers: pricingOffers,
 					})}
 				</script>
 			</Head>


### PR DESCRIPTION
## Summary

Adds the **Family** plan to the marketing site (pricing page + docs) ahead of the production launch.

- **Pricing card + Offer schema:** New Family `PricingCard` in `src/components/PricingSection.js` (up to 5 members, "Everything in Pro, plus:", annual-only "Annual only · Cancel anytime" framing, `plan=family` signup link). Added a `Family (annual)` entry to the structured-data `Offer` array, extracted into a testable `src/data/pricingOffers.js` module consumed by `pricing.js`. `PricingCard.js` gained `priceLabel`/`priceSuffix` props so the non-numeric TBD price renders cleanly.
- **Meta/OG copy:** Updated Layout `description`, `og:description`, and `twitter:description` in `src/pages/pricing.js` to enumerate "Family for up to 5 members".
- **Docs:** New `docs/features/family-plan.md` (seats, invitations, inherited access, automatic revocation, data-never-deleted, annual-only, links to pricing + location-sharing). Updated `docs/features/family.md` self-hosted-only note to reflect Cloud availability via the Family plan.

## Verification

- Vitest: **58 passed (8 files), 0 failed.** (Pre-existing CalendarRail duplicate-key React warnings are unrelated.)
- `npm run build`: **exit 0**, static files generated. Verified in build output: Family Offer JSON `"price":"TBD"`, rendered Family card, updated OG copy, built `family-plan` doc page.

## Deferred / blocked

- **Undecided annual price.** Price is `"TBD"` everywhere, with `TODO: set Family annual price before launch` in all three source locations (`PricingCard.js`, `pricingOffers.js`, `family-plan.md`) so it cannot ship silently. (Plan Phase 0.4.)
- **CTA target** — Family CTA uses the existing `sign_up?...&plan=family` pattern (same as the Lite card). Whether it should point at a reverse-trial checkout depends on the Phase 0.3 trial decision.
- **Manual Paddle product setup** — out of scope for this repo (manager/dawarich/Paddle phases).
- **E2E / other repos** — not part of this site change.

Plan: `/Users/frey/projects/dawarich/superpowers/plans/2026-05-31-family-plan-production-launch.md`