### PR TITLE
docs: correct Home Location section to match actual behavior

### DIFF
--- a/docs/features/visits-and-places.md
+++ b/docs/features/visits-and-places.md
@@ -53,10 +53,12 @@ Places are saved locations that can be associated with visits. When you confirm 
 
 ### Home Location
 
-Dawarich can automatically detect your home location based on where you spend the most time overnight. This helps with:
-- Filtering out home visits from statistics
-- Calculating time away from home
-- Trip detection
+You can mark where you live by creating a tag named **Home** and assigning it to a place:
+
+1. Create a tag named `Home` (see [Creating Tags](#creating-tags) below). The name is case-insensitive.
+2. Assign that tag to the place where you live.
+
+Dawarich uses this home location to center the map when you open it.
 
 ## Tags and Privacy Zones
 


### PR DESCRIPTION
## What

Rewrites the **Home Location** section in `docs/features/visits-and-places.md` so it matches what the app actually does.

## Why

The section claimed:

> Dawarich can automatically detect your home location based on where you spend the most time overnight.

…and listed stats filtering, time-away calculation, and trip detection as benefits. **None of this exists in the code.** The only "home" mechanism is `User#home_place_coordinates`: it looks up a tag named `Home` (case-insensitive), takes its first place's coordinates, and uses them to center the map. There is no overnight detection, and home is not wired to stats or trips.

This over-promise is what's behind the confusion in Freika/dawarich#2694 ("home detection is not working") — there is nothing to detect; the user has to tag a place `Home`.

## Change

Replaces the false auto-detection claim with the real, working manual steps (create a `Home` tag, assign it to a place; used to center the map).

## Verification

- `npm run build` → `[SUCCESS] Generated static files`. The new `#creating-tags` same-page anchor resolves (pre-existing `#pricing` broken-anchor warnings are unrelated to this change).

Addresses Freika/dawarich#2694