### PR TITLE
Replace Brevo newsletter iframe with Notifuse subscribe form

### DIFF
--- a/src/components/FinalCTA.js
+++ b/src/components/FinalCTA.js
@@ -1,6 +1,7 @@
 import Link from "@docusaurus/Link";
 import React from "react";
 import styles from "./FinalCTA.module.css";
+import NewsletterForm from "./NewsletterForm";
 
 export default function FinalCTA() {
 	return (
@@ -31,16 +32,7 @@ export default function FinalCTA() {
 							Get notified about new features and Google Timeline migration
 							tips.
 						</p>
-						<iframe
-							width="540"
-							height="500"
-							src="https://475728ae.sibforms.com/serve/MUIFAJLZJwZyy-W4PJAFc573ygtVeBn5fgINSOiVsmxzDKkjxeC96kVh_EVbvVN-hW4wCbGvIAPzrujZeSPpPbwUAXLZJfmGXHdmWG0208oNcTG4B20KmYDGdFhxs9Bos4UdurRT8dkzD_NjdRoMqg4A1_yAtpB5mHDbP_lT5mHAQIiamOmMomRSCEWWnFyk24LKJ6DqyhJze0By"
-							frameBorder="0"
-							scrolling="no"
-							allowFullScreen
-							className={styles.newsletterIframe}
-							title="Newsletter signup"
-						/>
+						<NewsletterForm />
 					</div>
 				</div>
 			</div>

--- a/src/components/FinalCTA.module.css
+++ b/src/components/FinalCTA.module.css
@@ -82,13 +82,6 @@
   margin: 0 0 1.5rem;
 }
 
-.newsletterIframe {
-  display: block;
-  max-width: 100%;
-  max-height: 100%;
-  border: none;
-}
-
 /* Dark mode support */
 [data-theme='dark'] .section {
   background: var(--dw-bg-elevated);
@@ -130,9 +123,5 @@
   .newsletterColumn {
     align-items: center;
     text-align: center;
-  }
-
-  .newsletterIframe {
-    max-width: 100%;
   }
 }

--- a/src/components/NewsletterForm.js
+++ b/src/components/NewsletterForm.js
@@ -1,0 +1,164 @@
+import React, { useState } from "react";
+import styles from "./NewsletterForm.module.css";
+
+// --- Notifuse config — replace these with your own values ---
+const NOTIFUSE_ENDPOINT = "https://emails.dawarich.app/subscribe";
+const WORKSPACE_ID = "dawarich";
+const LIST_IDS = ["dawarichnewsletter"];
+// ------------------------------------------------------------
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const STATUS = {
+	idle: "idle",
+	loading: "loading",
+	success: "success",
+	error: "error",
+};
+
+export default function NewsletterForm() {
+	const [email, setEmail] = useState("");
+	const [firstName, setFirstName] = useState("");
+	const [status, setStatus] = useState(STATUS.idle);
+	const [message, setMessage] = useState("");
+
+	const isLoading = status === STATUS.loading;
+	const isSuccess = status === STATUS.success;
+
+	async function handleSubmit(event) {
+		event.preventDefault();
+
+		const trimmedEmail = email.trim();
+		if (!EMAIL_PATTERN.test(trimmedEmail)) {
+			setStatus(STATUS.error);
+			setMessage("Please enter a valid email address.");
+			return;
+		}
+
+		setStatus(STATUS.loading);
+		setMessage("");
+
+		const contact = { email: trimmedEmail };
+		const trimmedFirstName = firstName.trim();
+		if (trimmedFirstName) {
+			contact.first_name = trimmedFirstName;
+		}
+
+		try {
+			const response = await fetch(NOTIFUSE_ENDPOINT, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					workspace_id: WORKSPACE_ID,
+					contact,
+					list_ids: LIST_IDS,
+				}),
+			});
+
+			let payload = {};
+			try {
+				payload = await response.json();
+			} catch {
+				payload = {};
+			}
+
+			if (!response.ok || payload.success !== true) {
+				const errorText =
+					payload.error || "Something went wrong. Please try again later.";
+				setStatus(STATUS.error);
+				setMessage(errorText);
+				return;
+			}
+
+			setStatus(STATUS.success);
+			setMessage("You're subscribed! Check your inbox to confirm.");
+			setEmail("");
+			setFirstName("");
+		} catch {
+			setStatus(STATUS.error);
+			setMessage("Network error. Please check your connection and try again.");
+		}
+	}
+
+	if (isSuccess) {
+		return (
+			<div className={styles.successPanel} role="status" aria-live="polite">
+				<svg
+					className={styles.successIcon}
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="2"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+					aria-hidden="true"
+				>
+					<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+					<polyline points="22 4 12 14.01 9 11.01" />
+				</svg>
+				<p className={styles.successText}>{message}</p>
+			</div>
+		);
+	}
+
+	return (
+		<form className={styles.form} onSubmit={handleSubmit} noValidate>
+			<div className={styles.field}>
+				<label className={styles.label} htmlFor="newsletter-first-name">
+					First name <span className={styles.optional}>(optional)</span>
+				</label>
+				<input
+					id="newsletter-first-name"
+					className={styles.input}
+					type="text"
+					name="first_name"
+					autoComplete="given-name"
+					placeholder="Evgenii"
+					value={firstName}
+					onChange={(e) => setFirstName(e.target.value)}
+					disabled={isLoading}
+				/>
+			</div>
+
+			<div className={styles.field}>
+				<label className={styles.label} htmlFor="newsletter-email">
+					Email <span className={styles.required}>*</span>
+				</label>
+				<input
+					id="newsletter-email"
+					className={styles.input}
+					type="email"
+					name="email"
+					autoComplete="email"
+					placeholder="you@example.com"
+					required
+					value={email}
+					onChange={(e) => setEmail(e.target.value)}
+					disabled={isLoading}
+					aria-invalid={status === STATUS.error}
+				/>
+			</div>
+
+			{status === STATUS.error && message && (
+				<p className={styles.errorText} role="alert" aria-live="assertive">
+					{message}
+				</p>
+			)}
+
+			<button className={styles.button} type="submit" disabled={isLoading}>
+				{isLoading ? (
+					<>
+						<span className={styles.spinner} aria-hidden="true" />
+						Subscribing…
+					</>
+				) : (
+					"Subscribe"
+				)}
+			</button>
+
+			<p className={styles.privacyNote}>
+				No spam. Unsubscribe anytime.
+			</p>
+		</form>
+	);
+}

--- a/src/components/NewsletterForm.module.css
+++ b/src/components/NewsletterForm.module.css
@@ -1,0 +1,168 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  max-width: 400px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  text-align: left;
+}
+
+.label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--dw-text);
+}
+
+.optional {
+  font-weight: 400;
+  color: var(--dw-text-secondary);
+}
+
+.required {
+  color: #EF4444;
+}
+
+.input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.625rem 0.875rem;
+  font-size: 0.9375rem;
+  color: var(--dw-text);
+  background: var(--dw-bg, #FFFFFF);
+  border: 1px solid var(--dw-border, #D1D5DB);
+  border-radius: 0.5rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.input::placeholder {
+  color: var(--dw-text-secondary);
+  opacity: 0.7;
+}
+
+.input:focus {
+  outline: none;
+  border-color: #3B82F6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+
+.input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.6875rem 1.25rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: #FFFFFF;
+  background: #3B82F6;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: box-shadow 0.2s ease, transform 0.2s ease, background 0.2s ease;
+}
+
+.button:hover:not(:disabled) {
+  background: #2563EB;
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.25);
+  transform: translateY(-1px);
+}
+
+.button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.spinner {
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  border-top-color: #FFFFFF;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.errorText {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: #DC2626;
+  text-align: left;
+}
+
+.privacyNote {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--dw-text-secondary);
+  text-align: left;
+}
+
+.successPanel {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+  width: 100%;
+  max-width: 400px;
+  padding: 1.5rem;
+  background: rgba(34, 197, 94, 0.08);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+  border-radius: 0.75rem;
+}
+
+.successIcon {
+  width: 2rem;
+  height: 2rem;
+  color: #16A34A;
+}
+
+.successText {
+  margin: 0;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  line-height: 1.6;
+  color: var(--dw-text);
+  text-align: left;
+}
+
+[data-theme='dark'] .input {
+  background: var(--dw-bg-sunken, #1B1B1D);
+  border-color: var(--dw-border, #3A3A3C);
+}
+
+[data-theme='dark'] .errorText {
+  color: #F87171;
+}
+
+@media (max-width: 768px) {
+  .form,
+  .successPanel {
+    max-width: 100%;
+    align-items: stretch;
+  }
+
+  .field,
+  .label,
+  .errorText,
+  .privacyNote,
+  .successText {
+    text-align: left;
+  }
+}


### PR DESCRIPTION
## What

Replaces the Brevo (sibforms) `<iframe>` in the Final CTA with a self-contained React form that posts to the Notifuse `/subscribe` endpoint.

## Why

Brings the newsletter signup in-house (Notifuse, self-hosted at `emails.dawarich.app`), giving us native styling, dark-mode support, and full control over validation and feedback instead of an opaque third-party iframe.

## Changes

- **`NewsletterForm.js`** (new) — email (required) + first name (optional), client-side email validation, loading state, success panel, and error handling for both Notifuse `{"error": ...}` responses and network failures.
- **`NewsletterForm.module.css`** (new) — responsive, dark-mode-aware, minimalist styling using existing design tokens.
- **`FinalCTA.js`** — renders `<NewsletterForm />` in place of the iframe.
- **`FinalCTA.module.css`** — removed the now-unused `.newsletterIframe` rules.

Notifuse config (endpoint, `workspace_id`, `list_ids`) lives in a labeled block at the top of `NewsletterForm.js` for easy replacement.

## Verification

- `npm run build` succeeds (pre-existing anchor/tag warnings only).
- Playwright against the served build confirmed: form renders, invalid email is rejected client-side, a successful submit posts the exact required JSON body with `Content-Type: application/json` and shows the success panel, and a server error surfaces to the user with the form left intact for retry.

## ⚠️ Follow-up (server-side, not in this PR)

The live Notifuse instance currently returns `Access-Control-Allow-Origin: https://emails.dawarich.app` (its own domain) and always sends `Access-Control-Allow-Credentials: true`, so browser requests are blocked by CORS. Set `CORS_ALLOW_ORIGIN=https://dawarich.app` on the `emails.dawarich.app` deployment for the live form to work. (Its CORS middleware supports only a single origin and can't use `*` alongside credentials.)