### PR TITLE
Redesign pricing cards, comparison matrix & versus table + Family waitlist

### DIFF
--- a/src/components/Comparison.js
+++ b/src/components/Comparison.js
@@ -1,156 +1,106 @@
 import React from "react";
+import { DwIcon } from "@site/src/data/pricingPlans";
 import styles from "./Comparison.module.css";
 
-const CheckIcon = () => (
-	<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-		<path
-			d="M13.5 4.5L6.5 12L2.5 8"
-			stroke="currentColor"
-			strokeWidth="2"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-		/>
-	</svg>
-);
-
-const CrossIcon = () => (
-	<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-		<path
-			d="M12 4L4 12M4 4L12 12"
-			stroke="currentColor"
-			strokeWidth="2"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-		/>
-	</svg>
-);
-
-const PartialIcon = () => (
-	<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-		<path
-			d="M3 8H13"
-			stroke="currentColor"
-			strokeWidth="2"
-			strokeLinecap="round"
-		/>
-	</svg>
-);
-
-const rows = [
-	{
-		feature: "Browser access",
-		google: "removed",
-		dawarich: "yes",
-		googleLabel: "Killed (mobile only)",
-		dawarichLabel: "Full web app",
-	},
-	{
-		feature: "Data retention",
-		google: "partial",
-		dawarich: "yes",
-		googleLabel: "Limited (auto-deletes)",
-		dawarichLabel: "Forever (Pro)",
-	},
-	{
-		feature: "Your data used for ads",
-		google: "bad",
-		dawarich: "no",
-		googleLabel: "Yes",
-		dawarichLabel: "Never",
-	},
-	{
-		feature: "Data sold to third parties",
-		google: "bad",
-		dawarich: "no",
-		googleLabel: "Yes (ad network)",
-		dawarichLabel: "Never",
-	},
-	{
-		feature: "Export your data",
-		google: "partial",
-		dawarich: "yes",
-		googleLabel: "Partial, complex",
-		dawarichLabel: "One-click, any format",
-	},
-	{
-		feature: "Self-host option",
-		google: "removed",
-		dawarich: "yes",
-		googleLabel: "No",
-		dawarichLabel: "Yes — full control",
-	},
-	{
-		feature: "Open source",
-		google: "removed",
-		dawarich: "yes",
-		googleLabel: "No",
-		dawarichLabel: "Yes — inspect every line",
-	},
-	{
-		feature: "Works if company kills the product",
-		google: "removed",
-		dawarich: "yes",
-		googleLabel: "No",
-		dawarichLabel: "Yes (self-host lives on)",
-	},
+// Content unchanged — restyled to match the new pricing section.
+const VERSUS_ROWS = [
+	{ feature: "Browser access", g: { mark: "x", text: "Killed (mobile only)" }, d: { mark: "check", text: "Full web app" } },
+	{ feature: "Data retention", g: { mark: "minus", text: "Limited (auto-deletes)" }, d: { mark: "check", text: "Forever (Pro)" } },
+	{ feature: "Your data used for ads", g: { mark: "x", text: "Yes" }, d: { mark: "check", text: "Never" } },
+	{ feature: "Data sold to third parties", g: { mark: "x", text: "Yes (ad network)" }, d: { mark: "check", text: "Never" } },
+	{ feature: "Export your data", g: { mark: "minus", text: "Partial, complex" }, d: { mark: "check", text: "One-click, any format" } },
+	{ feature: "Self-host option", g: { mark: "x", text: "No" }, d: { mark: "check", text: "Yes — full control" } },
+	{ feature: "Open source", g: { mark: "x", text: "No" }, d: { mark: "check", text: "Yes — inspect every line" } },
+	{ feature: "Works if company kills the product", g: { mark: "x", text: "No" }, d: { mark: "check", text: "Yes (self-host lives on)" } },
 ];
 
-function StatusIcon({ status }) {
-	if (status === "yes" || status === "no") {
-		return (
-			<span className={styles.iconGreen}>
-				<CheckIcon />
-			</span>
-		);
-	}
-	if (status === "partial") {
-		return (
-			<span className={styles.iconYellow}>
-				<PartialIcon />
-			</span>
-		);
-	}
+const SWITCH_HREF =
+	"https://my.dawarich.app/users/sign_up?utm_source=site&utm_medium=vs_table&utm_campaign=try7days";
+
+function VsCell({ cell, win }) {
+	const chipClass =
+		cell.mark === "check"
+			? styles.chipCheck
+			: cell.mark === "x"
+				? styles.chipX
+				: styles.chipMinus;
 	return (
-		<span className={styles.iconRed}>
-			<CrossIcon />
-		</span>
+		<div className={styles.cell}>
+			<span className={`${styles.chip} ${chipClass}`}>
+				<DwIcon name={cell.mark} size={15} stroke={2.6} />
+			</span>
+			<span className={win ? styles.cellTextWin : styles.cellText}>
+				{cell.text}
+			</span>
+		</div>
 	);
 }
 
 export default function Comparison() {
 	return (
 		<section className={styles.section}>
-			<div className={styles.container}>
+			<div className={styles.heading}>
+				<div className={styles.switchPill}>
+					<DwIcon name="arrow-down-up" size={13} stroke={2.2} /> Make the switch
+				</div>
 				<h2 className={styles.title}>Google Timeline vs Dawarich</h2>
 				<p className={styles.subtitle}>
 					See what you're gaining when you make the switch.
 				</p>
+			</div>
 
-				<div className={styles.tableWrapper}>
-					<table className={styles.table}>
-						<thead>
-							<tr>
-								<th className={styles.featureHeader}>Feature</th>
-								<th className={styles.googleHeader}>Google Timeline</th>
-								<th className={styles.dawarichHeader}>Dawarich</th>
-							</tr>
-						</thead>
-						<tbody>
-							{rows.map((row) => (
-								<tr key={row.feature} className={styles.row}>
-									<td className={styles.featureCell}>{row.feature}</td>
-									<td className={styles.googleCell}>
-										<StatusIcon status={row.google} />
-										<span>{row.googleLabel}</span>
-									</td>
-									<td className={styles.dawarichCell}>
-										<StatusIcon status={row.dawarich} />
-										<span>{row.dawarichLabel}</span>
-									</td>
-								</tr>
-							))}
-						</tbody>
-					</table>
+			<div className={styles.tableScroll}>
+				<div className={styles.table}>
+					{/* glowing highlight band behind the Dawarich column */}
+					<div className={styles.band} aria-hidden="true">
+						<div />
+						<div />
+						<div className={styles.bandCol}>
+							<div className={styles.bandAccent} />
+							<div className={styles.bandWash} />
+						</div>
+					</div>
+
+					{/* header */}
+					<div className={styles.headerRow}>
+						<div className={styles.colHead}>Feature</div>
+						<div className={styles.colHead}>Google Timeline</div>
+						<div className={styles.dawarichHead}>
+							<span className={styles.dawarichChip}>
+								<DwIcon name="map-pin" size={15} stroke={2.2} />
+							</span>
+							<span className={styles.dawarichName}>DAWARICH</span>
+						</div>
+					</div>
+
+					{/* rows */}
+					{VERSUS_ROWS.map((r, i) => (
+						<div
+							key={r.feature}
+							className={`${styles.row} ${i % 2 === 1 ? styles.rowAlt : ""}`}
+						>
+							<div className={styles.feature}>{r.feature}</div>
+							<VsCell cell={r.g} win={false} />
+							<VsCell cell={r.d} win={true} />
+						</div>
+					))}
+
+					{/* footer CTA */}
+					<div className={styles.footerRow}>
+						<div className={styles.footNote}>It's your data. Keep it that way.</div>
+						<div />
+						<div className={styles.footCtaCell}>
+							<a className={styles.footCta} href={SWITCH_HREF}>
+								Switch to Dawarich
+								<DwIcon
+									name="arrow-down-up"
+									size={15}
+									stroke={2.4}
+									className={styles.footCtaArrow}
+								/>
+							</a>
+						</div>
+					</div>
 				</div>
 			</div>
 		</section>

--- a/src/components/Comparison.module.css
+++ b/src/components/Comparison.module.css
@@ -1,202 +1,289 @@
+/* ============================================================
+   Google Timeline vs Dawarich — restyled to match the pricing
+   cards. Light/dark tokens mirror the design's dwTheme() object.
+   ============================================================ */
+
 .section {
-  padding: 6rem 1rem;
-  background: var(--ifm-color-background);
+	/* ── light tokens ── */
+	--card-bg: #ffffff;
+	--border: rgba(26, 26, 26, 0.07);
+	--text: #1a1a1a;
+	--muted: #6b7280;
+	--faint: #9ca3af;
+	--primary: #3b82f6;
+	--teal-bg: rgba(13, 148, 136, 0.1);
+	--teal-text: #0d7a70;
+	--amber-bg: rgba(245, 158, 11, 0.12);
+	--amber-text: #b45309;
+	--red-bg: rgba(239, 68, 68, 0.1);
+	--red-text: #dc2626;
+	--chip-blue-bg: rgba(59, 130, 246, 0.1);
+	--card-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
+	--grid: rgba(59, 130, 246, 0.05);
+	--band-grad: linear-gradient(180deg, rgba(59, 130, 246, 0.07) 0%, rgba(59, 130, 246, 0.025) 100%);
+	--band-border: rgba(59, 130, 246, 0.18);
+	--row-alt: rgba(0, 0, 0, 0.012);
+
+	--vs-cols: minmax(0, 1.4fr) minmax(0, 1fr) minmax(0, 1.15fr);
+
+	background: var(--ifm-color-background-alt);
+	padding: 5rem 1rem;
 }
 
-.container {
-  max-width: 900px;
-  margin: 0 auto;
-  padding: 0 1.5rem;
+[data-theme="dark"] .section {
+	--card-bg: #1c1c1c;
+	--border: rgba(234, 234, 234, 0.09);
+	--text: #eaeaea;
+	--muted: #8a8a8a;
+	--faint: #5c5c5c;
+	--primary: #60a5fa;
+	--teal-bg: rgba(45, 212, 191, 0.12);
+	--teal-text: #2dd4bf;
+	--amber-bg: rgba(251, 191, 36, 0.12);
+	--amber-text: #fbbf24;
+	--red-bg: rgba(248, 113, 113, 0.13);
+	--red-text: #f87171;
+	--chip-blue-bg: rgba(96, 165, 250, 0.14);
+	--card-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+	--grid: rgba(255, 255, 255, 0.035);
+	--band-grad: linear-gradient(180deg, rgba(96, 165, 250, 0.1) 0%, rgba(96, 165, 250, 0.04) 100%);
+	--band-border: rgba(96, 165, 250, 0.22);
+	--row-alt: rgba(255, 255, 255, 0.013);
 }
 
+/* ── Heading ── */
+.heading {
+	max-width: 620px;
+	margin: 0 auto 30px;
+	text-align: center;
+}
+.switchPill {
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	padding: 5px 13px;
+	margin-bottom: 14px;
+	border-radius: 9999px;
+	background: var(--chip-blue-bg);
+	color: var(--primary);
+	font-size: 12.5px;
+	font-weight: 700;
+	white-space: nowrap;
+}
 .title {
-  font-size: clamp(1.875rem, 4vw, 2.5rem);
-  font-weight: 700;
-  text-align: center;
-  color: var(--dw-text);
-  margin: 0 0 0.75rem;
-  letter-spacing: -0.025em;
+	margin: 0 0 8px;
+	font-size: 30px;
+	font-weight: 800;
+	letter-spacing: -0.02em;
+	color: var(--text);
 }
-
 .subtitle {
-  font-size: clamp(1rem, 2vw, 1.125rem);
-  line-height: 1.75;
-  text-align: center;
-  color: var(--dw-text-secondary);
-  margin: 0 auto 3rem;
-  max-width: 32rem;
+	margin: 0;
+	font-size: 15.5px;
+	line-height: 1.55;
+	color: var(--muted);
 }
 
-.tableWrapper {
-  overflow-x: auto;
-  border-radius: 1rem;
-  border: 1px solid var(--dw-border);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
+/* ── Table ── */
+.tableScroll {
+	max-width: 940px;
+	margin: 0 auto;
+	overflow-x: auto;
 }
-
 .table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.9375rem;
+	position: relative;
+	min-width: 640px;
+	background: var(--card-bg);
+	border: 1px solid var(--border);
+	border-radius: 18px;
+	box-shadow: var(--card-shadow);
+	overflow: hidden;
 }
 
-.table thead {
-  background: var(--dw-bg-sunken);
+/* glowing highlight band behind the Dawarich column */
+.band {
+	position: absolute;
+	inset: 0;
+	z-index: 0;
+	display: grid;
+	grid-template-columns: var(--vs-cols);
+	pointer-events: none;
+}
+.bandCol {
+	position: relative;
+	background: var(--band-grad);
+	border-left: 1px solid var(--band-border);
+}
+.bandAccent {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	height: 3px;
+	background: var(--primary);
+}
+.bandWash {
+	position: absolute;
+	inset: 0;
+	opacity: 0.7;
+	background-image: linear-gradient(var(--grid) 1px, transparent 1px),
+		linear-gradient(90deg, var(--grid) 1px, transparent 1px);
+	background-size: 24px 24px;
+	-webkit-mask-image: radial-gradient(120% 70% at 50% 0%, #000 0%, transparent 75%);
+	mask-image: radial-gradient(120% 70% at 50% 0%, #000 0%, transparent 75%);
 }
 
-.featureHeader,
-.googleHeader,
-.dawarichHeader {
-  padding: 1rem 1.25rem;
-  font-weight: 600;
-  font-size: 0.8125rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  text-align: left;
+/* ── Header ── */
+.headerRow {
+	position: relative;
+	z-index: 1;
+	display: grid;
+	grid-template-columns: var(--vs-cols);
+	border-bottom: 1px solid var(--border);
+}
+.colHead {
+	padding: 20px 22px;
+	align-self: center;
+	font-size: 12px;
+	font-weight: 700;
+	letter-spacing: 0.07em;
+	text-transform: uppercase;
+	color: var(--faint);
+}
+.dawarichHead {
+	padding: 20px 22px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+.dawarichChip {
+	width: 26px;
+	height: 26px;
+	border-radius: 7px;
+	background: var(--chip-blue-bg);
+	color: var(--primary);
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+.dawarichName {
+	font-size: 14px;
+	font-weight: 800;
+	letter-spacing: 0.04em;
+	color: var(--primary);
 }
 
-.featureHeader {
-  color: var(--dw-text-secondary);
-  width: 30%;
-}
-
-.googleHeader {
-  color: var(--dw-text-tertiary);
-  width: 35%;
-}
-
-.dawarichHeader {
-  color: var(--dw-primary);
-  width: 35%;
-}
-
+/* ── Rows ── */
 .row {
-  border-top: 1px solid var(--dw-border);
-  transition: background-color 0.15s ease;
+	position: relative;
+	z-index: 1;
+	display: grid;
+	grid-template-columns: var(--vs-cols);
+	min-height: 64px;
+	align-items: center;
+	border-bottom: 1px solid var(--border);
+}
+.row:last-of-type {
+	border-bottom: none;
+}
+.rowAlt {
+	background: var(--row-alt);
+}
+.feature {
+	padding: 14px 22px;
+	font-size: 15px;
+	font-weight: 600;
+	line-height: 1.3;
+	color: var(--text);
+}
+.cell {
+	display: flex;
+	align-items: center;
+	gap: 11px;
+	padding: 0 22px;
+}
+.chip {
+	flex: 0 0 auto;
+	width: 26px;
+	height: 26px;
+	border-radius: 8px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+.chipCheck {
+	background: var(--teal-bg);
+	color: var(--teal-text);
+}
+.chipX {
+	background: var(--red-bg);
+	color: var(--red-text);
+}
+.chipMinus {
+	background: var(--amber-bg);
+	color: var(--amber-text);
+}
+.cellText {
+	font-size: 15px;
+	line-height: 1.3;
+	font-weight: 500;
+	color: var(--muted);
+}
+.cellTextWin {
+	font-size: 15px;
+	line-height: 1.3;
+	font-weight: 600;
+	color: var(--text);
 }
 
-.row:hover {
-  background: rgba(59, 130, 246, 0.03);
+/* ── Footer CTA ── */
+.footerRow {
+	position: relative;
+	z-index: 1;
+	display: grid;
+	grid-template-columns: var(--vs-cols);
+	align-items: center;
+	border-top: 1px solid var(--border);
+}
+.footNote {
+	padding: 18px 22px;
+	font-size: 13.5px;
+	font-weight: 600;
+	color: var(--muted);
+}
+.footCtaCell {
+	padding: 14px 22px;
+}
+.footCta {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	border: 0;
+	cursor: pointer;
+	font-family: inherit;
+	font-size: 14px;
+	font-weight: 700;
+	color: #ffffff;
+	background: #3b82f6;
+	padding: 11px 18px;
+	border-radius: 10px;
+	white-space: nowrap;
+	text-decoration: none;
+	box-shadow: 0 4px 14px rgba(59, 130, 246, 0.32);
+	transition: transform 160ms ease, box-shadow 160ms ease;
+}
+.footCta:hover {
+	color: #ffffff;
+	text-decoration: none;
+	transform: translateY(-1px);
+	box-shadow: 0 8px 22px rgba(59, 130, 246, 0.42);
+}
+.footCtaArrow {
+	transform: rotate(90deg);
 }
 
-.featureCell {
-  padding: 0.875rem 1.25rem;
-  font-weight: 500;
-  color: var(--dw-text);
-}
-
-.googleCell,
-.dawarichCell {
-  padding: 0.875rem 1.25rem;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: var(--dw-text-secondary);
-}
-
-/* Use table-cell display for proper table layout */
-.googleCell,
-.dawarichCell {
-  display: table-cell;
-  vertical-align: middle;
-}
-
-.googleCell span,
-.dawarichCell span {
-  vertical-align: middle;
-}
-
-.googleCell svg,
-.dawarichCell svg {
-  display: inline-block;
-  vertical-align: middle;
-  margin-right: 0.5rem;
-}
-
-.iconGreen {
-  color: var(--ifm-color-accent);
-}
-
-.iconRed {
-  color: #EF4444;
-}
-
-.iconYellow {
-  color: #F59E0B;
-}
-
-/* Dark mode */
-[data-theme='dark'] .section {
-  background: var(--ifm-color-background);
-}
-
-[data-theme='dark'] .title {
-  color: var(--dw-text);
-}
-
-[data-theme='dark'] .subtitle {
-  color: var(--dw-text-secondary);
-}
-
-[data-theme='dark'] .tableWrapper {
-  border-color: var(--dw-border);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
-}
-
-[data-theme='dark'] .table thead {
-  background: var(--dw-bg-elevated);
-}
-
-[data-theme='dark'] .featureHeader {
-  color: var(--dw-text-secondary);
-}
-
-[data-theme='dark'] .googleHeader {
-  color: var(--dw-text-tertiary);
-}
-
-[data-theme='dark'] .dawarichHeader {
-  color: #60A5FA;
-}
-
-[data-theme='dark'] .row {
-  border-top-color: var(--dw-bg-hover);
-}
-
-[data-theme='dark'] .row:hover {
-  background: rgba(59, 130, 246, 0.05);
-}
-
-[data-theme='dark'] .featureCell {
-  color: var(--dw-text);
-}
-
-[data-theme='dark'] .googleCell,
-[data-theme='dark'] .dawarichCell {
-  color: var(--dw-text-secondary);
-}
-
-/* Responsive */
-@media (max-width: 640px) {
-  .section {
-    padding: 4rem 0.5rem;
-  }
-
-  .featureHeader,
-  .googleHeader,
-  .dawarichHeader {
-    padding: 0.75rem;
-    font-size: 0.6875rem;
-  }
-
-  .featureCell,
-  .googleCell,
-  .dawarichCell {
-    padding: 0.625rem 0.75rem;
-    font-size: 0.8125rem;
-  }
-
-  .featureCell {
-    width: 25%;
-  }
+@media (prefers-reduced-motion: reduce) {
+	.footCta {
+		transition: none;
+	}
 }

--- a/src/components/PricingCard.js
+++ b/src/components/PricingCard.js
@@ -1,139 +1,146 @@
 import Link from "@docusaurus/Link";
 import React, { useState } from "react";
+import { DwIcon } from "@site/src/data/pricingPlans";
+import WaitlistForm from "./WaitlistForm";
 import styles from "./PricingCard.module.css";
 
-export default function PricingCard({
-	className,
-	title = "Annual Subscription",
-	annualPrice = 120,
-	monthlyPrice = null,
-	description = "Full access to all features.",
-	perDayText = null,
-	features = [],
-	proOnlyFeatures = [],
-	includesLabel = null,
-	buttonText = "Get Started",
-	buttonLink = "/pricing",
-	buttonVariant = "primary",
-	trialText = null,
-	badge = null,
-	disabled = false,
-}) {
-	const [isAnnual, setIsAnnual] = useState(true);
-	const hasMonthly = monthlyPrice !== null;
+export default function PricingCard({ plan, popular = false, deemph = false }) {
+	const [billing, setBilling] = useState("annual");
+	const isPro = plan.key === "pro";
+	const monthly = isPro && billing === "monthly";
+	const bigPrice = monthly ? plan.priceMonthly : plan.price;
+	const bigPeriod = monthly ? plan.periodMonthly : plan.period;
 
-	const displayPrice = isAnnual || !hasMonthly ? annualPrice : monthlyPrice;
-	const displayPeriod = isAnnual || !hasMonthly ? "year" : "month";
-	const monthlyEquivalent = (annualPrice / 12).toFixed(2);
-
-	const perDayAmount = isAnnual || !hasMonthly
-		? (annualPrice / 365).toFixed(2)
-		: (monthlyPrice / 30).toFixed(2);
+	const cardClass = [
+		styles.card,
+		plan.accent === "teal" ? styles.accentTeal : styles.accentBlue,
+		popular ? styles.popular : "",
+		deemph ? styles.deemph : "",
+	]
+		.filter(Boolean)
+		.join(" ");
 
 	return (
-		<div
-			className={`${styles.pricingCard} ${className || ""} ${disabled ? styles.disabled : ""}`}
-		>
-			{badge && <div className={styles.planBadge}>{badge}</div>}
-			<h2 className={styles.title}>{title}</h2>
+		<div className={cardClass}>
+			{popular && <div className={styles.mapWash} aria-hidden="true" />}
 
-			<div className={styles.priceContainer}>
-				<div className={styles.mainPrice}>
-					<span className={styles.currency}>&euro;</span>
-					<span className={styles.currentPrice}>{displayPrice}</span>
-					<span className={styles.period}>/{displayPeriod}</span>
+			{popular && (
+				<div className={styles.ribbon}>
+					<DwIcon name="sparkles" size={12} stroke={2.4} /> MOST POPULAR
 				</div>
-				{(isAnnual || !hasMonthly) && (
-					<div className={styles.equivalentPrice}>
-						&euro;{monthlyEquivalent}/month
-					</div>
-				)}
+			)}
+			{deemph && <div className={styles.comingSoon}>COMING SOON</div>}
+
+			<div className={styles.header}>
+				<span className={styles.planIcon}>
+					<DwIcon name={plan.icon} size={20} stroke={2} />
+				</span>
+				<span className={styles.planName}>{plan.name}</span>
 			</div>
 
-			{hasMonthly && (
-				<div className={styles.toggleContainer}>
-					<div className={styles.toggleTrack}>
-						<button
-							className={`${styles.toggleButton} ${!isAnnual ? styles.active : ""}`}
-							onClick={() => setIsAnnual(false)}
-							disabled={disabled}
-						>
-							Monthly
-						</button>
-						<button
-							className={`${styles.toggleButton} ${isAnnual ? styles.active : ""}`}
-							onClick={() => setIsAnnual(true)}
-							disabled={disabled}
-						>
-							Annual
-						</button>
+			{plan.price && (
+				<div className={styles.priceBlock}>
+					<div className={styles.priceTopRow}>
+						{plan.oldPrice && !monthly && (
+							<span className={styles.oldPrice}>&euro;{plan.oldPrice}</span>
+						)}
+						{isPro && plan.save && !monthly && (
+							<span className={styles.saveBadge}>
+								<DwIcon name="trending-up" size={12} stroke={2.4} /> {plan.save}
+							</span>
+						)}
 					</div>
-					{isAnnual && monthlyPrice && (
-						<span className={styles.saveBadge}>
-							Save {Math.round((1 - annualPrice / (monthlyPrice * 12)) * 100)}%
-						</span>
+					<div className={styles.priceMainRow}>
+						<span className={styles.currency}>&euro;</span>
+						<span className={styles.bigPrice}>{bigPrice}</span>
+						<span className={styles.period}>{bigPeriod}</span>
+					</div>
+					<div className={styles.perMonth}>
+						{monthly ? "billed monthly" : plan.perMonth}
+					</div>
+				</div>
+			)}
+
+			{isPro && (
+				<div className={styles.toggleRow}>
+					<div className={styles.toggleTrack}>
+						{["monthly", "annual"].map((opt) => (
+							<button
+								key={opt}
+								type="button"
+								className={`${styles.toggleBtn} ${billing === opt ? styles.toggleActive : ""}`}
+								onClick={() => setBilling(opt)}
+							>
+								{opt}
+							</button>
+						))}
+					</div>
+					{billing === "monthly" && (
+						<span className={styles.toggleHint}>Save 44% on annual &rarr;</span>
 					)}
 				</div>
 			)}
 
-			{perDayText && <div className={styles.perDay}>&euro;{perDayAmount}/day</div>}
+			{plan.urgency && (
+				<div className={styles.urgency}>
+					<DwIcon name="lock" size={15} stroke={2} className={styles.urgencyIcon} />
+					<span>{plan.urgency}</span>
+				</div>
+			)}
 
-			<p className={styles.description}>{description}</p>
+			{(monthly ? plan.perDayMonthly : plan.perDay) && (
+				<div className={styles.perDay}>
+					<DwIcon name="zap" size={13} stroke={2.4} />{" "}
+					{monthly ? plan.perDayMonthly : plan.perDay}
+				</div>
+			)}
+
+			<p className={styles.tagline}>{plan.tagline}</p>
 
 			<div className={styles.divider} />
 
-			{includesLabel && (
-				<div className={styles.includesLabel}>{includesLabel}</div>
+			{plan.featuresHeading && (
+				<div className={styles.featuresHeading}>{plan.featuresHeading}</div>
 			)}
 
-			<ul className={styles.featuresList}>
-				{features.map((feature, index) => (
-					<li key={index} className={styles.featureItem}>
-						<span className={styles.checkIcon}>
-							<svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-								<path
-									d="M11.5 3.5L5.5 10L2.5 7"
-									stroke="currentColor"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-								/>
-							</svg>
+			<ul className={styles.features}>
+				{plan.features.map((f, i) => (
+					<li key={i} className={styles.featureRow}>
+						<span className={styles.featureChip}>
+							<DwIcon name={f.icon} size={15} stroke={2} />
 						</span>
-						<span className={styles.featureText}>{feature}</span>
-					</li>
-				))}
-				{proOnlyFeatures.map((feature, index) => (
-					<li key={`pro-${index}`} className={`${styles.featureItem} ${styles.proFeature}`}>
-						<span className={`${styles.checkIcon} ${styles.proCheckIcon}`}>
-							<svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-								<path
-									d="M11.5 3.5L5.5 10L2.5 7"
-									stroke="currentColor"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-								/>
-							</svg>
-						</span>
-						<span className={styles.featureText}>
-							{feature}
-						</span>
+						<span className={styles.featureLabel}>{f.label}</span>
 					</li>
 				))}
 			</ul>
 
-			{buttonLink && (
-				<Link
-					to={buttonLink}
-					className={`${styles.ctaButton} ${styles[buttonVariant]} ${disabled ? styles.disabledButton : ""}`}
-					aria-disabled={disabled}
-				>
-					{buttonText}
-				</Link>
-			)}
+			<div className={styles.spacer} />
 
-			{trialText && <p className={styles.trialText}>{trialText}</p>}
+			{plan.waitlistListId ? (
+				<WaitlistForm
+					listId={plan.waitlistListId}
+					heading="Join the Family waitlist"
+					subtext="Be first to know the moment it launches — annual only, every Pro feature."
+					buttonLabel="Join the waitlist"
+					note="No spam, just the launch email."
+				/>
+			) : (
+				<>
+					<div className={styles.guarantee}>
+						<DwIcon name="shield-check" size={15} stroke={2} /> 14-day money-back
+						guarantee
+					</div>
+
+					<Link
+						to={plan.href}
+						className={`${styles.cta} ${plan.ctaStyle === "primary" ? styles.ctaPrimary : styles.ctaOutline}`}
+					>
+						{plan.cta}
+					</Link>
+
+					<div className={styles.footnote}>{plan.footnote}</div>
+				</>
+			)}
 		</div>
 	);
 }

--- a/src/components/PricingCard.module.css
+++ b/src/components/PricingCard.module.css
@@ -1,412 +1,485 @@
-/* ── Card shell ── */
-.pricingCard {
-  background-color: #FFFFFF;
-  border-radius: 16px;
-  border: 1px solid var(--dw-border);
-  padding: 40px 32px 32px;
-  width: 100%;
-  text-align: center;
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  transition: box-shadow 0.3s ease, transform 0.3s ease;
+/* ============================================================
+   Pricing card — refined design (light + dark via [data-theme])
+   Light/dark token sets mirror the design's dwTheme() object.
+   ============================================================ */
+
+.card {
+	/* ── light tokens ── */
+	--card-bg: #ffffff;
+	--card-bg-alt: #fcfcfb;
+	--pro-bg: #ffffff;
+	--border: rgba(26, 26, 26, 0.07);
+	--text: #1a1a1a;
+	--text2: #4b4b4b;
+	--muted: #6b7280;
+	--faint: #9ca3af;
+	--primary: #3b82f6;
+	--teal: #0d9488;
+	--amber-bg: rgba(245, 158, 11, 0.12);
+	--amber-text: #b45309;
+	--amber-border: rgba(245, 158, 11, 0.25);
+	--teal-bg: rgba(13, 148, 136, 0.1);
+	--teal-text: #0d7a70;
+	--chip-blue-bg: rgba(59, 130, 246, 0.1);
+	--chip-teal-bg: rgba(13, 148, 136, 0.1);
+	--strike: #9ca3af;
+	--grid: rgba(59, 130, 246, 0.05);
+	--tog-bg: #ededea;
+	--tog-active: #ffffff;
+	--tog-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+	--card-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
+	--card-shadow-hover: 0 18px 40px -14px rgba(0, 0, 0, 0.22);
+	--pro-shadow: 0 0 0 1.5px #3b82f6, 0 22px 48px -16px rgba(59, 130, 246, 0.4);
+	--ribbon-bg: #3b82f6;
+	--ribbon-text: #ffffff;
+	--ribbon-border: transparent;
+
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	border-radius: 16px;
+	padding: 30px 26px 26px;
+	background: var(--card-bg);
+	border: 1px solid var(--border);
+	box-shadow: var(--card-shadow);
+	overflow: hidden;
+	text-align: left;
+	transition: transform 200ms cubic-bezier(0.2, 0.7, 0.3, 1), box-shadow 200ms ease;
 }
 
-.pricingCard:hover {
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.08);
-  transform: translateY(-2px);
+[data-theme="dark"] .card {
+	--card-bg: #1c1c1c;
+	--card-bg-alt: #161616;
+	--pro-bg: linear-gradient(180deg, #1d2330 0%, #161a22 100%);
+	--border: rgba(234, 234, 234, 0.09);
+	--text: #eaeaea;
+	--text2: #b8b8b8;
+	--muted: #8a8a8a;
+	--faint: #5c5c5c;
+	--primary: #60a5fa;
+	--teal: #2dd4bf;
+	--amber-bg: rgba(251, 191, 36, 0.12);
+	--amber-text: #fbbf24;
+	--amber-border: rgba(251, 191, 36, 0.22);
+	--teal-bg: rgba(45, 212, 191, 0.12);
+	--teal-text: #2dd4bf;
+	--chip-blue-bg: rgba(96, 165, 250, 0.14);
+	--chip-teal-bg: rgba(45, 212, 191, 0.14);
+	--strike: #6b6b6b;
+	--grid: rgba(255, 255, 255, 0.035);
+	--tog-bg: #0f0f0f;
+	--tog-active: #2a2f3a;
+	--tog-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+	--card-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+	--card-shadow-hover: 0 18px 44px -16px rgba(0, 0, 0, 0.8);
+	--pro-shadow: 0 0 0 1px rgba(96, 165, 250, 0.45), 0 18px 50px -12px rgba(59, 130, 246, 0.45);
+	--ribbon-bg: rgba(96, 165, 250, 0.18);
+	--ribbon-text: #bfdbfe;
+	--ribbon-border: rgba(96, 165, 250, 0.4);
 }
 
-/* ── Badge ── */
-.planBadge {
-  position: absolute;
-  top: -10px;
-  right: -10px;
-  z-index: 2;
-  background: linear-gradient(135deg, #3B82F6, #6366F1);
-  color: white;
-  font-size: 0.7rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  padding: 0.375rem 0.875rem;
-  border-radius: 9999px;
-  box-shadow: 0 2px 8px rgba(59, 130, 246, 0.3);
+/* per-card accent resolution */
+.accentBlue {
+	--accent: var(--primary);
+	--accent-chip: var(--chip-blue-bg);
+}
+.accentTeal {
+	--accent: var(--teal);
+	--accent-chip: var(--chip-teal-bg);
 }
 
-/* ── Title ── */
-.title {
-  font-size: 1.5rem;
-  font-weight: 700;
-  color: var(--dw-text);
-  margin: 0 0 1.25rem;
+.card:hover {
+	transform: translateY(-6px);
+	box-shadow: var(--card-shadow-hover);
 }
 
-/* ── Billing toggle (pill style) ── */
-.toggleContainer {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 1.25rem;
+/* Featured (Pro) */
+.popular {
+	background: var(--pro-bg);
+	border-color: transparent;
+	box-shadow: var(--pro-shadow);
+	transform: translateY(-10px);
+	z-index: 2;
+}
+.popular:hover {
+	transform: translateY(-10px);
+	box-shadow: var(--pro-shadow);
 }
 
-.toggleTrack {
-  display: inline-flex;
-  background: var(--dw-bg-sunken);
-  border-radius: 9999px;
-  padding: 3px;
-  gap: 2px;
+/* De-emphasized (Family) */
+.deemph {
+	background: var(--card-bg-alt);
+	opacity: 0.94;
 }
 
-.toggleButton {
-  padding: 6px 18px;
-  border: none;
-  background: transparent;
-  color: var(--dw-text-secondary);
-  border-radius: 9999px;
-  font-size: 0.8125rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
+/* keep in-flow content above the map wash (but NOT the absolutely-positioned
+   overlays — excluding them so they keep position:absolute) */
+.card > *:not(.mapWash):not(.ribbon):not(.comingSoon) {
+	position: relative;
+	z-index: 1;
 }
 
-.toggleButton:hover:not(:disabled):not(.active) {
-  color: var(--dw-text);
+/* ── Map-grid wash (Pro only) ── */
+.mapWash {
+	position: absolute;
+	inset: 0;
+	z-index: 0;
+	pointer-events: none;
+	background-image: linear-gradient(var(--grid) 1px, transparent 1px),
+		linear-gradient(90deg, var(--grid) 1px, transparent 1px);
+	background-size: 26px 26px;
+	-webkit-mask-image: radial-gradient(120% 80% at 50% 0%, #000 0%, transparent 70%);
+	mask-image: radial-gradient(120% 80% at 50% 0%, #000 0%, transparent 70%);
 }
 
-.toggleButton.active {
-  background: #FFFFFF;
-  color: var(--dw-text);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+/* ── Ribbon / coming-soon badge ── */
+.ribbon {
+	position: absolute;
+	top: 16px;
+	right: 16px;
+	z-index: 3;
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	padding: 5px 12px;
+	border-radius: 9999px;
+	background: var(--ribbon-bg);
+	color: var(--ribbon-text);
+	border: 1px solid var(--ribbon-border);
+	font-size: 11px;
+	font-weight: 700;
+	letter-spacing: 0.06em;
+	white-space: nowrap;
 }
 
-.toggleButton:disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
+.comingSoon {
+	position: absolute;
+	top: 16px;
+	right: 16px;
+	z-index: 3;
+	padding: 5px 11px;
+	border-radius: 9999px;
+	background: var(--teal-bg);
+	color: var(--teal-text);
+	font-size: 11px;
+	font-weight: 700;
+	letter-spacing: 0.05em;
+	white-space: nowrap;
 }
 
-.saveBadge {
-  font-size: 0.7rem;
-  font-weight: 600;
-  color: #059669;
-  background: #ecfdf5;
-  padding: 0.15rem 0.5rem;
-  border-radius: 9999px;
+/* ── Header ── */
+.header {
+	display: flex;
+	align-items: center;
+	gap: 11px;
+	margin-bottom: 14px;
+}
+.planIcon {
+	width: 38px;
+	height: 38px;
+	border-radius: 10px;
+	background: var(--accent-chip);
+	color: var(--accent);
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+.planName {
+	font-size: 21px;
+	font-weight: 700;
+	letter-spacing: -0.01em;
+	color: var(--text);
 }
 
 /* ── Price ── */
-.priceContainer {
-  text-align: center;
-  margin: 1.5rem 0;
+.priceBlock {
+	margin-bottom: 14px;
 }
-
-.mainPrice {
-  display: flex;
-  align-items: baseline;
-  justify-content: center;
-  line-height: 1;
+.priceTopRow {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin-bottom: 6px;
+	min-height: 22px;
 }
-
+.oldPrice {
+	font-size: 15px;
+	font-weight: 600;
+	color: var(--strike);
+	text-decoration: line-through;
+	font-variant-numeric: tabular-nums;
+}
+.saveBadge {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	padding: 2px 9px;
+	border-radius: 9999px;
+	background: var(--teal-bg);
+	color: var(--teal-text);
+	font-size: 12px;
+	font-weight: 700;
+	white-space: nowrap;
+}
+.priceMainRow {
+	display: flex;
+	align-items: flex-start;
+	gap: 3px;
+}
 .currency {
-  font-size: 1.5rem;
-  font-weight: 600;
-  color: var(--dw-text);
-  align-self: flex-start;
-  margin-top: 0.35rem;
+	font-size: 26px;
+	font-weight: 700;
+	color: var(--text);
+	margin-top: 6px;
 }
-
-.currentPrice {
-  font-size: 3.25rem;
-  font-weight: 700;
-  color: var(--dw-text);
-  letter-spacing: -0.025em;
+.bigPrice {
+	font-size: 60px;
+	font-weight: 800;
+	letter-spacing: -0.035em;
+	line-height: 0.95;
+	color: var(--text);
+	font-variant-numeric: tabular-nums;
 }
-
 .period {
-  font-size: 1rem;
-  font-weight: 500;
-  color: var(--dw-text-secondary);
-  margin-left: 0.125rem;
+	font-size: 15px;
+	font-weight: 500;
+	color: var(--muted);
+	align-self: flex-end;
+	margin: 0 0 10px 2px;
+}
+.perMonth {
+	margin-top: 6px;
+	font-size: 13px;
+	font-weight: 500;
+	color: var(--faint);
 }
 
-.equivalentPrice {
-  color: var(--dw-text-tertiary);
-  font-size: 0.85rem;
-  margin-top: 0.375rem;
+/* TBD (Family) */
+.tbdRow {
+	display: flex;
+	align-items: baseline;
+	gap: 4px;
+}
+.tbdCurrency {
+	font-size: 22px;
+	font-weight: 700;
+	color: var(--muted);
+}
+.tbdValue {
+	font-size: 50px;
+	font-weight: 800;
+	letter-spacing: -0.03em;
+	line-height: 1;
+	color: var(--muted);
+}
+.tbdPeriod {
+	font-size: 15px;
+	font-weight: 500;
+	color: var(--faint);
 }
 
-/* ── Per-day price ── */
+/* ── Pro billing toggle ── */
+.toggleRow {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin-bottom: 14px;
+	flex-wrap: wrap;
+}
+.toggleTrack {
+	display: inline-flex;
+	background: var(--tog-bg);
+	border: 1px solid var(--border);
+	border-radius: 9999px;
+	padding: 3px;
+}
+.toggleBtn {
+	border: 0;
+	cursor: pointer;
+	font-family: inherit;
+	padding: 6px 16px;
+	border-radius: 9999px;
+	font-size: 13px;
+	font-weight: 600;
+	text-transform: capitalize;
+	background: transparent;
+	color: var(--muted);
+	transition: all 150ms ease;
+}
+.toggleActive {
+	background: var(--tog-active);
+	color: var(--text);
+	box-shadow: var(--tog-shadow);
+}
+.toggleHint {
+	font-size: 12.5px;
+	font-weight: 600;
+	color: var(--teal-text);
+}
+
+/* ── Urgency banner ── */
+.urgency {
+	display: flex;
+	align-items: center;
+	gap: 9px;
+	margin-bottom: 12px;
+	padding: 9px 12px;
+	border-radius: 10px;
+	background: var(--amber-bg);
+	color: var(--amber-text);
+	border: 1px solid var(--amber-border);
+	font-size: 12.5px;
+	font-weight: 600;
+	line-height: 1.35;
+}
+.urgencyIcon {
+	flex: 0 0 auto;
+}
+
+/* ── Per-day pill ── */
 .perDay {
-  font-size: 0.8125rem;
-  font-weight: 600;
-  color: #059669;
-  background: #ecfdf5;
-  display: inline-block;
-  padding: 0.25rem 0.75rem;
-  border-radius: 9999px;
-  margin-bottom: 0.75rem;
+	display: inline-flex;
+	align-self: flex-start;
+	align-items: center;
+	gap: 7px;
+	margin-bottom: 14px;
+	padding: 6px 13px;
+	border-radius: 9999px;
+	background: var(--teal-bg);
+	color: var(--teal-text);
+	font-size: 13.5px;
+	font-weight: 700;
+	white-space: nowrap;
 }
 
-[data-theme='dark'] .perDay {
-  background: rgba(5, 150, 105, 0.15);
-  color: #34d399;
+/* ── Tagline / divider ── */
+.tagline {
+	margin: 0 0 18px;
+	font-size: 14px;
+	line-height: 1.5;
+	color: var(--muted);
 }
-
-/* ── Description ── */
-.description {
-  font-size: 0.9375rem;
-  line-height: 1.6;
-  color: var(--dw-text-secondary);
-  margin: 0 0 1.5rem;
-}
-
-/* ── Divider ── */
 .divider {
-  height: 1px;
-  background: var(--dw-border);
-  margin: 0 0 1.5rem;
+	height: 1px;
+	background: var(--border);
+	margin-bottom: 16px;
 }
 
-/* ── "Includes" label ── */
-.includesLabel {
-  font-size: 0.8125rem;
-  font-weight: 600;
-  color: #3B82F6;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  margin-bottom: 1rem;
-  text-align: left;
+/* ── Features ── */
+.featuresHeading {
+	font-size: 11.5px;
+	font-weight: 700;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--accent);
+	margin-bottom: 8px;
+}
+.features {
+	list-style: none;
+	margin: 0 0 18px;
+	padding: 0;
+}
+.featureRow {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 7px 0;
+}
+.featureChip {
+	flex: 0 0 auto;
+	width: 28px;
+	height: 28px;
+	border-radius: 8px;
+	background: var(--accent-chip);
+	color: var(--accent);
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+.featureLabel {
+	font-size: 14.5px;
+	line-height: 1.3;
+	font-weight: 500;
+	color: var(--text2);
 }
 
-/* ── Feature list ── */
-.featuresList {
-  list-style: none;
-  padding: 0;
-  margin: 0 0 2rem;
-  text-align: left;
-  flex-grow: 1;
+.spacer {
+	flex: 1;
+	min-height: 8px;
 }
 
-.featureItem {
-  display: flex;
-  align-items: flex-start;
-  font-size: 0.9375rem;
-  color: var(--dw-text);
-  margin-bottom: 0.875rem;
-  line-height: 1.4;
+/* ── Guarantee ── */
+.guarantee {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 7px;
+	margin-bottom: 14px;
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--teal-text);
 }
 
-.checkIcon {
-  flex-shrink: 0;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background: #eff6ff;
-  color: #3B82F6;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  margin-right: 0.75rem;
-  margin-top: 1px;
+/* ── CTA ── */
+.cta {
+	width: 100%;
+	border: 0;
+	cursor: pointer;
+	font-family: inherit;
+	padding: 14px 16px;
+	border-radius: 10px;
+	font-size: 15px;
+	font-weight: 700;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	text-decoration: none;
+	transition: all 160ms ease;
+}
+.ctaPrimary {
+	background: #3b82f6;
+	color: #ffffff;
+	box-shadow: 0 4px 14px rgba(59, 130, 246, 0.3);
+}
+.ctaPrimary:hover {
+	color: #ffffff;
+	text-decoration: none;
+	transform: translateY(-1px);
+	box-shadow: 0 8px 22px rgba(59, 130, 246, 0.45);
+}
+.ctaOutline {
+	background: transparent;
+	color: var(--accent);
+	box-shadow: inset 0 0 0 1.5px var(--accent);
+}
+.ctaOutline:hover {
+	color: var(--accent);
+	text-decoration: none;
+	background: var(--accent-chip);
 }
 
-.featureText {
-  flex: 1;
+/* ── Footnote ── */
+.footnote {
+	text-align: center;
+	margin-top: 10px;
+	font-size: 12px;
+	color: var(--faint);
 }
 
-/* ── Pro-only features highlight ── */
-.proFeature {
-  font-weight: 500;
+@media (prefers-reduced-motion: reduce) {
+	.card,
+	.cta {
+		transition: none;
+	}
 }
 
-.proCheckIcon {
-  background: rgba(13, 148, 136, 0.12);
-  color: #0D9488;
-}
-
-[data-theme='dark'] .proCheckIcon {
-  background: rgba(45, 212, 191, 0.15);
-  color: #2DD4BF;
-}
-
-/* ── CTA buttons ── */
-.ctaButton {
-  width: 100%;
-  display: block;
-  text-align: center;
-  padding: 0.875rem 1.5rem;
-  margin-top: auto;
-  font-weight: 600;
-  font-size: 0.9375rem;
-  border-radius: 10px;
-  text-decoration: none;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-/* Primary: solid blue (Pro) */
-.primary {
-  background: linear-gradient(135deg, #3B82F6, #2563EB);
-  color: white;
-  border: none;
-  box-shadow: 0 2px 8px rgba(59, 130, 246, 0.25);
-}
-
-.primary:hover {
-  background: linear-gradient(135deg, #2563EB, #1D4ED8);
-  color: white;
-  text-decoration: none;
-  box-shadow: 0 4px 16px rgba(59, 130, 246, 0.35);
-  transform: translateY(-1px);
-}
-
-/* Secondary: outlined (Lite) */
-.secondary {
-  background: transparent;
-  color: #3B82F6;
-  border: 2px solid #3B82F6;
-}
-
-.secondary:hover {
-  background: #eff6ff;
-  color: #2563EB;
-  border-color: #2563EB;
-  text-decoration: none;
-  transform: translateY(-1px);
-}
-
-/* ── Trial text ── */
-.trialText {
-  font-size: 0.8125rem;
-  color: var(--dw-text-tertiary);
-  margin: 0.75rem 0 0;
-}
-
-/* ── Dark mode ── */
-[data-theme='dark'] .pricingCard {
-  background-color: #1C1C1C;
-  border-color: #2A2A2A;
-}
-
-[data-theme='dark'] .pricingCard:hover {
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-}
-
-[data-theme='dark'] .title {
-  color: #EAEAEA;
-}
-
-[data-theme='dark'] .currency,
-[data-theme='dark'] .currentPrice {
-  color: #EAEAEA;
-}
-
-[data-theme='dark'] .period {
-  color: #9A9A9A;
-}
-
-[data-theme='dark'] .description {
-  color: #9A9A9A;
-}
-
-[data-theme='dark'] .trialText {
-  color: #636363;
-}
-
-[data-theme='dark'] .equivalentPrice {
-  color: #636363;
-}
-
-[data-theme='dark'] .divider {
-  background: #2A2A2A;
-}
-
-[data-theme='dark'] .featureItem {
-  color: #EAEAEA;
-}
-
-[data-theme='dark'] .checkIcon {
-  background: rgba(96, 165, 250, 0.15);
-  color: #60A5FA;
-}
-
-[data-theme='dark'] .includesLabel {
-  color: #60A5FA;
-}
-
-[data-theme='dark'] .toggleTrack {
-  background: #282828;
-}
-
-[data-theme='dark'] .toggleButton {
-  color: #9A9A9A;
-}
-
-[data-theme='dark'] .toggleButton:hover:not(:disabled):not(.active) {
-  color: #EAEAEA;
-}
-
-[data-theme='dark'] .toggleButton.active {
-  background: #363636;
-  color: #EAEAEA;
-  box-shadow: none;
-}
-
-[data-theme='dark'] .saveBadge {
-  background: rgba(5, 150, 105, 0.15);
-  color: #34d399;
-}
-
-[data-theme='dark'] .secondary {
-  color: #60A5FA;
-  border-color: #60A5FA;
-}
-
-[data-theme='dark'] .secondary:hover {
-  background: rgba(96, 165, 250, 0.1);
-  color: #60A5FA;
-  border-color: #60A5FA;
-}
-
-/* ── Disabled state ── */
-.disabled {
-  opacity: 0.7;
-  background-color: #F5F5F3;
-  box-shadow: none;
-  cursor: not-allowed;
-}
-
-.disabledButton {
-  background-color: #999999 !important;
-  background-image: none !important;
-  border-color: #999999 !important;
-  color: white !important;
-  cursor: not-allowed;
-  pointer-events: none;
-  box-shadow: none !important;
-}
-
-[data-theme='dark'] .disabled {
-  background-color: #282828;
-  opacity: 0.7;
-}
-
-[data-theme='dark'] .disabledButton {
-  background-color: #363636 !important;
-}
-
-/* ── Responsive ── */
 @media (max-width: 768px) {
-  .pricingCard {
-    padding: 32px 24px 24px;
-  }
-
-  .currentPrice {
-    font-size: 2.5rem;
-  }
-
-  .currency {
-    font-size: 1.25rem;
-  }
+	.card {
+		padding: 26px 22px 22px;
+	}
+	.bigPrice {
+		font-size: 52px;
+	}
 }

--- a/src/components/PricingCompare.js
+++ b/src/components/PricingCompare.js
@@ -1,0 +1,205 @@
+import React, { useState } from "react";
+import { COMPARE_GROUPS, DwIcon } from "@site/src/data/pricingPlans";
+import styles from "./PricingCompare.module.css";
+
+const COLS = [
+	{ key: "lite", name: "Lite", sub: "€49.99/yr", accent: "blue", popular: false },
+	{ key: "pro", name: "Pro", sub: "€119.99/yr", accent: "blue", popular: true },
+	{ key: "family", name: "Family", sub: "Coming soon", accent: "teal", popular: false },
+];
+
+// Comparison table gets its own UTM tagging, distinct from the pricing cards
+// (cards use utm_medium=pricing; this section uses utm_medium=pricing_compare).
+const COMPARE_UTM = "utm_source=site&utm_medium=pricing_compare";
+const CTA_LINKS = {
+	lite: `https://my.dawarich.app/users/sign_up?${COMPARE_UTM}&utm_campaign=try7dayslite&utm_content=compare_lite&plan=lite`,
+	pro: `https://my.dawarich.app/users/sign_up?${COMPARE_UTM}&utm_campaign=try7days&utm_content=compare_pro`,
+	family: "#pricing",
+};
+
+const norm = (v) => (v === true ? "✓" : v === false ? "✗" : String(v));
+const rowIsDifferent = (row) =>
+	!(norm(row.lite) === norm(row.pro) && norm(row.pro) === norm(row.family));
+
+function CellMark({ value, accent }) {
+	if (value === true) {
+		return (
+			<span
+				className={`${styles.cellCheck} ${accent === "teal" ? styles.cellCheckTeal : styles.cellCheckBlue}`}
+			>
+				<DwIcon name="check" size={14} stroke={2.6} />
+			</span>
+		);
+	}
+	if (value === false) {
+		return (
+			<span className={styles.cellMinus}>
+				<DwIcon name="minus" size={16} stroke={2.4} />
+			</span>
+		);
+	}
+	return <span className={styles.cellText}>{value}</span>;
+}
+
+export default function PricingCompare() {
+	const [open, setOpen] = useState(() => {
+		const o = {};
+		COMPARE_GROUPS.forEach((g) => {
+			o[g.name] = true;
+		});
+		return o;
+	});
+	const [diffOnly, setDiffOnly] = useState(false);
+	const allOpen = COMPARE_GROUPS.every((g) => open[g.name]);
+	const toggle = (name) => setOpen((p) => ({ ...p, [name]: !p[name] }));
+	const setAll = (v) => {
+		const o = {};
+		COMPARE_GROUPS.forEach((g) => {
+			o[g.name] = v;
+		});
+		setOpen(o);
+	};
+
+	return (
+		<section className={styles.compare}>
+			<div className={styles.inner}>
+				<div className={styles.head}>
+					<div>
+						<h2 className={styles.title}>Compare every feature</h2>
+						<p className={styles.subtitle}>
+							Expand a section to see the details — or just show what changes
+							between plans.
+						</p>
+					</div>
+					<div className={styles.controls}>
+						<button
+							type="button"
+							className={styles.ctrlBtn}
+							onClick={() => setAll(!allOpen)}
+						>
+							{allOpen ? "Collapse all" : "Expand all"}
+						</button>
+						<button
+							type="button"
+							className={`${styles.ctrlBtn} ${diffOnly ? styles.ctrlBtnActive : ""}`}
+							onClick={() => setDiffOnly((v) => !v)}
+							aria-pressed={diffOnly}
+						>
+							<span className={`${styles.switch} ${diffOnly ? styles.switchOn : ""}`}>
+								<span className={styles.knob} />
+							</span>
+							Highlight differences
+						</button>
+					</div>
+				</div>
+
+				<div className={styles.tableScroll}>
+					<div className={styles.table}>
+						<div className={styles.headerRow}>
+							<div className={styles.headerFeatures}>Features</div>
+							{COLS.map((c) => (
+								<div
+									key={c.key}
+									className={`${styles.headerCol} ${c.popular ? styles.popCol : ""}`}
+								>
+									{c.popular && <div className={styles.colTopBar} />}
+									<div className={styles.colName}>
+										{c.popular && (
+											<DwIcon
+												name="sparkles"
+												size={13}
+												stroke={2.4}
+												className={styles.colSpark}
+											/>
+										)}
+										{c.name}
+									</div>
+									<div
+										className={`${styles.colSub} ${c.accent === "teal" ? styles.colSubTeal : ""}`}
+									>
+										{c.sub}
+									</div>
+								</div>
+							))}
+						</div>
+
+						{COMPARE_GROUPS.map((g, gi) => {
+							const rows = diffOnly ? g.rows.filter(rowIsDifferent) : g.rows;
+							if (diffOnly && rows.length === 0) return null;
+							const isOpen = open[g.name];
+							return (
+								<div
+									key={g.name}
+									className={
+										gi < COMPARE_GROUPS.length - 1 ? styles.group : styles.groupLast
+									}
+								>
+									<button
+										type="button"
+										className={styles.groupHeader}
+										onClick={() => toggle(g.name)}
+										aria-expanded={isOpen}
+									>
+										<span className={styles.groupTitleCell}>
+											<span
+												className={`${styles.chevron} ${isOpen ? "" : styles.chevronClosed}`}
+											>
+												<DwIcon name="chevron-down" size={16} stroke={2.4} />
+											</span>
+											<span className={styles.groupName}>{g.name}</span>
+											<span className={styles.groupCount}>{rows.length}</span>
+										</span>
+										<span />
+										<span />
+										<span />
+									</button>
+									{isOpen &&
+										rows.map((row, ri) => {
+											const diff = rowIsDifferent(row);
+											return (
+												<div
+													key={ri}
+													className={`${styles.row} ${diffOnly && diff ? styles.rowDiff : ""}`}
+												>
+													<div className={styles.rowLabel}>{row.label}</div>
+													{COLS.map((c) => (
+														<div
+															key={c.key}
+															className={`${styles.cell} ${c.popular ? styles.popCell : ""}`}
+														>
+															<CellMark value={row[c.key]} accent={c.accent} />
+														</div>
+													))}
+												</div>
+											);
+										})}
+								</div>
+							);
+						})}
+
+						<div className={styles.footerRow}>
+							<div className={styles.footerLabel}>Ready when you are</div>
+							{COLS.map((c) => (
+								<div
+									key={c.key}
+									className={`${styles.footerCell} ${c.popular ? styles.popCell : ""}`}
+								>
+									<a
+										href={CTA_LINKS[c.key]}
+										className={`${styles.footCta} ${c.popular ? styles.footCtaPrimary : c.accent === "teal" ? styles.footCtaTeal : styles.footCtaBlue}`}
+									>
+										{c.key === "family"
+											? "Notify me"
+											: c.key === "pro"
+												? "Start free"
+												: "Choose Lite"}
+									</a>
+								</div>
+							))}
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/src/components/PricingCompare.module.css
+++ b/src/components/PricingCompare.module.css
@@ -1,0 +1,354 @@
+/* ============================================================
+   Feature comparison matrix — light + dark via [data-theme]
+   Token sets mirror the design's dwTheme() object.
+   ============================================================ */
+
+.compare {
+	/* ── light tokens ── */
+	--card-bg: #ffffff;
+	--header-bg: #fcfcfb;
+	--border: rgba(26, 26, 26, 0.07);
+	--border-strong: rgba(26, 26, 26, 0.12);
+	--text: #1a1a1a;
+	--text2: #4b4b4b;
+	--muted: #6b7280;
+	--faint: #9ca3af;
+	--primary: #3b82f6;
+	--teal: #0d9488;
+	--teal-text: #0d7a70;
+	--chip-blue-bg: rgba(59, 130, 246, 0.1);
+	--chip-teal-bg: rgba(13, 148, 136, 0.1);
+	--card-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
+	--pop-head: rgba(59, 130, 246, 0.05);
+	--pop-cell: rgba(59, 130, 246, 0.025);
+	--row-diff: rgba(59, 130, 246, 0.03);
+	--diff-border: #3b82f6;
+
+	background: var(--ifm-color-background-alt);
+	padding: 4rem 1rem 5rem;
+	font-variant-numeric: tabular-nums;
+}
+
+[data-theme="dark"] .compare {
+	--card-bg: #1c1c1c;
+	--header-bg: #161616;
+	--border: rgba(234, 234, 234, 0.09);
+	--border-strong: rgba(234, 234, 234, 0.16);
+	--text: #eaeaea;
+	--text2: #b8b8b8;
+	--muted: #8a8a8a;
+	--faint: #5c5c5c;
+	--primary: #60a5fa;
+	--teal: #2dd4bf;
+	--teal-text: #2dd4bf;
+	--chip-blue-bg: rgba(96, 165, 250, 0.14);
+	--chip-teal-bg: rgba(45, 212, 191, 0.14);
+	--card-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+	--pop-head: rgba(96, 165, 250, 0.08);
+	--pop-cell: rgba(96, 165, 250, 0.04);
+	--row-diff: rgba(96, 165, 250, 0.05);
+	--diff-border: rgba(96, 165, 250, 0.5);
+}
+
+.inner {
+	max-width: 1120px;
+	margin: 0 auto;
+}
+
+/* ── Header + controls ── */
+.head {
+	display: flex;
+	align-items: flex-end;
+	justify-content: space-between;
+	gap: 16px;
+	margin-bottom: 18px;
+	flex-wrap: wrap;
+}
+.title {
+	margin: 0 0 4px;
+	font-size: 26px;
+	font-weight: 800;
+	letter-spacing: -0.02em;
+	color: var(--text);
+}
+.subtitle {
+	margin: 0;
+	font-size: 14.5px;
+	color: var(--muted);
+}
+.controls {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	flex-wrap: wrap;
+}
+.ctrlBtn {
+	border: 1px solid var(--border-strong);
+	background: transparent;
+	cursor: pointer;
+	font-family: inherit;
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--text2);
+	padding: 8px 14px;
+	border-radius: 9999px;
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	transition: all 160ms ease;
+}
+.ctrlBtnActive {
+	border-color: var(--diff-border);
+	background: var(--chip-blue-bg);
+	color: var(--primary);
+}
+.switch {
+	width: 30px;
+	height: 17px;
+	border-radius: 9999px;
+	padding: 2px;
+	flex: 0 0 auto;
+	background: var(--border-strong);
+	display: inline-flex;
+	transition: background 160ms ease;
+}
+.switchOn {
+	background: var(--primary);
+}
+.knob {
+	width: 13px;
+	height: 13px;
+	border-radius: 9999px;
+	background: #fff;
+	transform: translateX(0);
+	transition: transform 160ms ease;
+}
+.switchOn .knob {
+	transform: translateX(13px);
+}
+
+/* ── Table ── */
+.tableScroll {
+	overflow-x: auto;
+}
+.table {
+	--grid-cols: minmax(0, 1.5fr) repeat(3, minmax(0, 1fr));
+	min-width: 680px;
+	background: var(--card-bg);
+	border: 1px solid var(--border);
+	border-radius: 16px;
+	box-shadow: var(--card-shadow);
+	overflow: hidden;
+}
+
+.headerRow {
+	display: grid;
+	grid-template-columns: var(--grid-cols);
+	border-bottom: 1px solid var(--border);
+	background: var(--header-bg);
+}
+.headerFeatures {
+	padding: 18px 20px;
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--muted);
+	align-self: center;
+}
+.headerCol {
+	padding: 16px 12px;
+	text-align: center;
+	position: relative;
+}
+.popCol {
+	background: var(--pop-head);
+}
+.colTopBar {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	height: 3px;
+	background: var(--primary);
+}
+.colName {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 16px;
+	font-weight: 700;
+	color: var(--text);
+}
+.colSpark {
+	color: var(--primary);
+}
+.colSub {
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--muted);
+	margin-top: 2px;
+}
+.colSubTeal {
+	color: var(--teal-text);
+}
+
+/* ── Groups ── */
+.group {
+	border-bottom: 1px solid var(--border);
+}
+.groupHeader {
+	width: 100%;
+	border: 0;
+	background: transparent;
+	cursor: pointer;
+	font-family: inherit;
+	display: grid;
+	grid-template-columns: var(--grid-cols);
+	align-items: center;
+	text-align: left;
+}
+.groupTitleCell {
+	display: flex;
+	align-items: center;
+	gap: 9px;
+	padding: 14px 20px;
+}
+.chevron {
+	color: var(--muted);
+	display: inline-flex;
+	transition: transform 180ms ease;
+}
+.chevronClosed {
+	transform: rotate(-90deg);
+}
+.groupName {
+	font-size: 13.5px;
+	font-weight: 700;
+	color: var(--text);
+	letter-spacing: 0.01em;
+}
+.groupCount {
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--faint);
+}
+
+/* ── Rows ── */
+.row {
+	display: grid;
+	grid-template-columns: var(--grid-cols);
+	align-items: center;
+}
+.rowDiff {
+	background: var(--row-diff);
+}
+.rowLabel {
+	padding: 11px 20px 11px 45px;
+	font-size: 14px;
+	font-weight: 500;
+	color: var(--text2);
+}
+.cell {
+	padding: 11px 12px;
+	display: flex;
+	justify-content: center;
+}
+.popCell {
+	background: var(--pop-cell);
+}
+.cellCheck {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	border-radius: 9999px;
+}
+.cellCheckBlue {
+	background: var(--chip-blue-bg);
+	color: var(--primary);
+}
+.cellCheckTeal {
+	background: var(--chip-teal-bg);
+	color: var(--teal);
+}
+.cellMinus {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	color: var(--faint);
+	opacity: 0.8;
+}
+.cellText {
+	font-size: 13.5px;
+	font-weight: 700;
+	color: var(--text);
+}
+
+/* ── CTA footer ── */
+.footerRow {
+	display: grid;
+	grid-template-columns: var(--grid-cols);
+	align-items: center;
+	border-top: 1px solid var(--border);
+	background: var(--header-bg);
+}
+.footerLabel {
+	padding: 16px 20px;
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--muted);
+}
+.footerCell {
+	padding: 14px 12px;
+	text-align: center;
+}
+.footCta {
+	display: inline-block;
+	width: 90%;
+	cursor: pointer;
+	font-family: inherit;
+	font-size: 13px;
+	font-weight: 700;
+	padding: 9px 16px;
+	border-radius: 9999px;
+	text-decoration: none;
+	transition: all 160ms ease;
+}
+.footCtaPrimary {
+	border: 0;
+	background: #3b82f6;
+	color: #fff;
+	box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+}
+.footCtaPrimary:hover {
+	color: #fff;
+	text-decoration: none;
+	transform: translateY(-1px);
+}
+.footCtaBlue {
+	border: 1.5px solid var(--primary);
+	background: transparent;
+	color: var(--primary);
+}
+.footCtaTeal {
+	border: 1.5px solid var(--teal);
+	background: transparent;
+	color: var(--teal);
+}
+.footCtaBlue:hover,
+.footCtaTeal:hover {
+	text-decoration: none;
+	background: var(--chip-blue-bg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.chevron,
+	.knob,
+	.switch,
+	.ctrlBtn,
+	.footCta {
+		transition: none;
+	}
+}

--- a/src/components/PricingSection.js
+++ b/src/components/PricingSection.js
@@ -1,5 +1,6 @@
 import Link from "@docusaurus/Link";
 import React from "react";
+import { PLANS } from "@site/src/data/pricingPlans";
 import PricingCard from "./PricingCard";
 import styles from "./PricingSection.module.css";
 
@@ -12,61 +13,19 @@ export default function PricingSection() {
 				<h2 className={styles.title}>Own Your Location History</h2>
 
 				<p className={styles.subtitle}>
-					Less than a coffee per week to keep a lifetime of memories. Your data
-					is always yours — export everything, anytime, on any plan.
+					Less than €1 a week to keep a lifetime of memories. Your data is always
+					yours — export everything, anytime, on any plan.
 				</p>
 
 				<div className={styles.cardContainer}>
 					<div className={styles.cardWrapper}>
-						<PricingCard
-							title="Lite"
-							annualPrice={49.99}
-							description="A private alternative to Google Timeline for casual trackers."
-							perDayText={"Less than \u20AC0.14/day"}
-							features={[
-								"iOS & Android native apps",
-								"Background location tracking",
-								"12 months of searchable history",
-								"Unlimited imports & exports",
-								"Interactive map with routes",
-								"Speed-colored routes & daily replay",
-								"Trips & places management",
-								"Basic stats & monthly breakdowns",
-								"200 req/hr API rate limit",
-							]}
-							buttonText="Try Lite Free"
-							buttonVariant="secondary"
-							buttonLink="https://my.dawarich.app/users/sign_up?utm_source=site&utm_medium=pricing&utm_campaign=try7dayslite&plan=lite"
-							trialText="Annual only · Cancel anytime"
-						/>
+						<PricingCard plan={PLANS.lite} />
 					</div>
-
-					<div className={styles.featuredCardWrapper}>
-						<PricingCard
-							className={styles.featuredCard}
-							title="Pro"
-							annualPrice={119.99}
-							monthlyPrice={17.99}
-							badge="Most Popular"
-							description="Unlimited history, advanced visualizations, and full API access."
-							perDayText={"Just \u20AC0.33/day"}
-							includesLabel="Everything in Lite, plus:"
-							features={[]}
-							proOnlyFeatures={[
-								"Unlimited data history — forever",
-								"Heatmap & Fog of War layers",
-								"Globe view (3D)",
-								"Trip photo integration",
-								"Immich / PhotoPrism integration",
-								"Full year-in-review & public sharing",
-								"Full Write API access",
-								"1,000 req/hr API rate limit",
-							]}
-							buttonText="Start Pro Free — 7 Days"
-							buttonVariant="primary"
-							buttonLink="https://my.dawarich.app/users/sign_up?utm_source=site&utm_medium=pricing&utm_campaign=try7days"
-							trialText="Cancel anytime"
-						/>
+					<div className={styles.cardWrapper}>
+						<PricingCard plan={PLANS.pro} popular />
+					</div>
+					<div className={styles.cardWrapper}>
+						<PricingCard plan={PLANS.family} deemph />
 					</div>
 				</div>
 
@@ -87,10 +46,12 @@ export default function PricingSection() {
 						</svg>
 					</div>
 					<div className={styles.guaranteeText}>
-						<strong>14-day risk-free refund.</strong> Try Dawarich for 7 days
-						free, then for 14 days after subscribing — change your mind and we
-						refund you, no questions asked. Your data export is always yours to
-						keep.{" "}
+						<strong>
+							Import your Google Timeline in 10 minutes — or let us do it for
+							you, free.
+						</strong>{" "}
+						And you're covered by a 14-day money-back guarantee: change your mind
+						after subscribing and we refund you, no questions asked.{" "}
 						<Link to="/refund-policy" className={styles.guaranteeLink}>
 							Refund policy →
 						</Link>

--- a/src/components/PricingSection.module.css
+++ b/src/components/PricingSection.module.css
@@ -5,7 +5,7 @@
 }
 
 .container {
-  max-width: 1280px;
+  max-width: 1400px;
   margin: 0 auto;
   padding: 0 1.5rem;
 }
@@ -43,9 +43,9 @@
   display: flex;
   justify-content: center;
   align-items: stretch;
-  gap: 2rem;
+  gap: 1.75rem;
   margin-top: 3rem;
-  max-width: 56rem;
+  max-width: 84rem;
   margin-left: auto;
   margin-right: auto;
 }

--- a/src/components/WaitlistForm.js
+++ b/src/components/WaitlistForm.js
@@ -1,0 +1,140 @@
+import React, { useState } from "react";
+import styles from "./WaitlistForm.module.css";
+
+// --- Notifuse config (matches the newsletter form's approach) ---
+const NOTIFUSE_ENDPOINT = "https://emails.dawarich.app/subscribe";
+const WORKSPACE_ID = "dawarich";
+// ----------------------------------------------------------------
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const STATUS = {
+	idle: "idle",
+	loading: "loading",
+	success: "success",
+	error: "error",
+};
+
+export default function WaitlistForm({
+	listId,
+	heading = null,
+	subtext = null,
+	buttonLabel = "Join the waitlist",
+	note = "No spam — just the launch email.",
+}) {
+	const [email, setEmail] = useState("");
+	const [status, setStatus] = useState(STATUS.idle);
+	const [message, setMessage] = useState("");
+
+	const isLoading = status === STATUS.loading;
+
+	async function handleSubmit(event) {
+		event.preventDefault();
+
+		const trimmedEmail = email.trim();
+		if (!EMAIL_PATTERN.test(trimmedEmail)) {
+			setStatus(STATUS.error);
+			setMessage("Please enter a valid email address.");
+			return;
+		}
+
+		setStatus(STATUS.loading);
+		setMessage("");
+
+		try {
+			const response = await fetch(NOTIFUSE_ENDPOINT, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					workspace_id: WORKSPACE_ID,
+					contact: { email: trimmedEmail },
+					list_ids: [listId],
+				}),
+			});
+
+			let payload = {};
+			try {
+				payload = await response.json();
+			} catch {
+				payload = {};
+			}
+
+			if (!response.ok || payload.success !== true) {
+				setStatus(STATUS.error);
+				setMessage(payload.error || "Something went wrong. Please try again later.");
+				return;
+			}
+
+			setStatus(STATUS.success);
+			setMessage("You're on the list! We'll email you when Family launches.");
+			setEmail("");
+		} catch {
+			setStatus(STATUS.error);
+			setMessage("Network error. Please check your connection and try again.");
+		}
+	}
+
+	if (status === STATUS.success) {
+		return (
+			<div className={styles.success} role="status" aria-live="polite">
+				<svg
+					className={styles.successIcon}
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="2"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+					aria-hidden="true"
+				>
+					<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+					<polyline points="22 4 12 14.01 9 11.01" />
+				</svg>
+				<span>{message}</span>
+			</div>
+		);
+	}
+
+	return (
+		<form className={styles.form} onSubmit={handleSubmit} noValidate>
+			{(heading || subtext) && (
+				<div className={styles.prompt}>
+					{heading && <div className={styles.promptTitle}>{heading}</div>}
+					{subtext && <p className={styles.promptText}>{subtext}</p>}
+				</div>
+			)}
+			<input
+				className={styles.input}
+				type="email"
+				name="email"
+				autoComplete="email"
+				placeholder="you@example.com"
+				required
+				value={email}
+				onChange={(e) => setEmail(e.target.value)}
+				disabled={isLoading}
+				aria-label="Email address"
+				aria-invalid={status === STATUS.error}
+			/>
+
+			{status === STATUS.error && message && (
+				<p className={styles.error} role="alert" aria-live="assertive">
+					{message}
+				</p>
+			)}
+
+			<button className={styles.button} type="submit" disabled={isLoading}>
+				{isLoading ? (
+					<>
+						<span className={styles.spinner} aria-hidden="true" />
+						Joining…
+					</>
+				) : (
+					buttonLabel
+				)}
+			</button>
+
+			<p className={styles.note}>{note}</p>
+		</form>
+	);
+}

--- a/src/components/WaitlistForm.module.css
+++ b/src/components/WaitlistForm.module.css
@@ -1,0 +1,137 @@
+/* Email-only waitlist form — inherits the card's CSS custom properties
+   (--accent, --text, --border, --faint, --teal-text, --accent-chip). */
+
+.form {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.prompt {
+	margin-bottom: 2px;
+}
+.promptTitle {
+	font-size: 14px;
+	font-weight: 700;
+	color: var(--text);
+}
+.promptText {
+	margin: 3px 0 0;
+	font-size: 13px;
+	line-height: 1.45;
+	color: var(--muted);
+}
+
+.input {
+	width: 100%;
+	padding: 12px 14px;
+	border-radius: 10px;
+	border: 1.5px solid var(--border);
+	background: transparent;
+	color: var(--text);
+	font-family: inherit;
+	font-size: 14px;
+	transition: border-color 150ms ease;
+}
+.input::placeholder {
+	color: var(--faint);
+}
+.input:focus {
+	outline: none;
+	border-color: var(--accent);
+}
+
+.button {
+	width: 100%;
+	border: 0;
+	cursor: pointer;
+	font-family: inherit;
+	padding: 13px 16px;
+	border-radius: 10px;
+	font-size: 15px;
+	font-weight: 700;
+	color: #ffffff;
+	background: var(--accent);
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	transition: transform 160ms ease, filter 160ms ease;
+}
+.button:hover:not(:disabled) {
+	transform: translateY(-1px);
+	filter: brightness(1.06);
+}
+.button:disabled {
+	opacity: 0.7;
+	cursor: not-allowed;
+}
+
+/* bright teal in dark mode needs dark text for contrast */
+[data-theme="dark"] .button {
+	color: #08110f;
+}
+
+.spinner {
+	width: 15px;
+	height: 15px;
+	border-radius: 50%;
+	border: 2px solid rgba(255, 255, 255, 0.4);
+	border-top-color: #ffffff;
+	animation: waitlistSpin 0.7s linear infinite;
+}
+[data-theme="dark"] .spinner {
+	border-color: rgba(8, 17, 15, 0.35);
+	border-top-color: #08110f;
+}
+
+@keyframes waitlistSpin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+.error {
+	margin: 0;
+	font-size: 12.5px;
+	font-weight: 600;
+	color: #dc2626;
+}
+[data-theme="dark"] .error {
+	color: #f87171;
+}
+
+.note {
+	margin: 4px 0 0;
+	text-align: center;
+	font-size: 12px;
+	color: var(--faint);
+}
+
+.success {
+	display: flex;
+	align-items: center;
+	gap: 9px;
+	padding: 14px 16px;
+	border-radius: 10px;
+	background: var(--accent-chip);
+	color: var(--teal-text);
+	font-size: 13.5px;
+	font-weight: 600;
+	line-height: 1.4;
+}
+.successIcon {
+	flex: 0 0 auto;
+	width: 18px;
+	height: 18px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.input,
+	.button {
+		transition: none;
+	}
+	.spinner {
+		animation: none;
+	}
+}

--- a/src/data/pricingPlans.js
+++ b/src/data/pricingPlans.js
@@ -1,0 +1,192 @@
+import React from "react";
+
+export const DW_ICONS = {
+	smartphone: '<rect width="14" height="20" x="5" y="2" rx="2" ry="2"/><path d="M12 18h.01"/>',
+	"map-pin": '<path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"/><circle cx="12" cy="10" r="3"/>',
+	calendar: '<path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/>',
+	"arrow-down-up": '<path d="m3 16 4 4 4-4"/><path d="M7 20V4"/><path d="m21 8-4-4-4 4"/><path d="M17 4v16"/>',
+	map: '<path d="M14.106 5.553a2 2 0 0 0 1.788 0l3.659-1.83A1 1 0 0 1 21 4.619v12.764a1 1 0 0 1-.553.894l-4.553 2.277a2 2 0 0 1-1.788 0l-4.212-2.106a2 2 0 0 0-1.788 0l-3.659 1.83A1 1 0 0 1 3 19.381V6.618a1 1 0 0 1 .553-.894l4.553-2.277a2 2 0 0 1 1.788 0z"/><path d="M15 5.764v15"/><path d="M9 3.236v15"/>',
+	route: '<circle cx="6" cy="19" r="3"/><path d="M9 19h8.5a3.5 3.5 0 0 0 0-7h-11a3.5 3.5 0 0 1 0-7H15"/><circle cx="18" cy="5" r="3"/>',
+	flag: '<path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z"/><line x1="4" x2="4" y1="22" y2="15"/>',
+	"chart-column": '<path d="M3 3v16a2 2 0 0 0 2 2h16"/><path d="M18 17V9"/><path d="M13 17V5"/><path d="M8 17v-3"/>',
+	zap: '<path d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"/>',
+	infinity: '<path d="M12 12c-2-2.67-4-4-6-4a4 4 0 1 0 0 8c2 0 4-1.33 6-4Zm0 0c2 2.67 4 4 6 4a4 4 0 0 0 0-8c-2 0-4 1.33-6 4Z"/>',
+	flame: '<path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z"/>',
+	layers: '<path d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"/><path d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"/><path d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"/>',
+	globe: '<circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/>',
+	camera: '<path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z"/><circle cx="12" cy="13" r="3"/>',
+	share: '<circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" x2="15.42" y1="13.51" y2="17.49"/><line x1="15.41" x2="8.59" y1="6.51" y2="10.49"/>',
+	"square-pen": '<path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z"/>',
+	users: '<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/>',
+	"badge-check": '<path d="M3.85 8.62a4 4 0 0 1 4.78-4.77 4 4 0 0 1 6.74 0 4 4 0 0 1 4.78 4.78 4 4 0 0 1 0 6.74 4 4 0 0 1-4.77 4.78 4 4 0 0 1-6.75 0 4 4 0 0 1-4.78-4.77 4 4 0 0 1 0-6.76Z"/><path d="m9 12 2 2 4-4"/>',
+	"shield-check": '<path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/>',
+	"map-pin-plus": '<path d="M19.914 11.105A7.298 7.298 0 0 0 20 10a8 8 0 0 0-16 0c0 4.993 5.539 10.193 7.399 11.799a1 1 0 0 0 1.202 0 32 32 0 0 0 .824-.738"/><circle cx="12" cy="10" r="3"/><path d="M16 18h6"/><path d="M19 15v6"/>',
+	sparkles: '<path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .962 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.962 0z"/><path d="M20 3v4"/><path d="M22 5h-4"/><path d="M4 17v2"/><path d="M5 18H3"/>',
+	crown: '<path d="M11.562 3.266a.5.5 0 0 1 .876 0L15.39 8.87a1 1 0 0 0 1.516.294L21.183 5.5a.5.5 0 0 1 .798.519l-2.834 10.246a1 1 0 0 1-.956.734H5.81a1 1 0 0 1-.957-.734L2.02 6.02a.5.5 0 0 1 .798-.519l4.276 3.664a1 1 0 0 0 1.516-.294z"/><path d="M5 21h14"/>',
+	star: '<path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"/>',
+	check: '<path d="M20 6 9 17l-5-5"/>',
+	x: '<path d="M18 6 6 18"/><path d="m6 6 12 12"/>',
+	minus: '<path d="M5 12h14"/>',
+	"chevron-down": '<path d="m6 9 6 6 6-6"/>',
+	lock: '<rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>',
+	"trending-up": '<path d="M16 7h6v6"/><path d="m22 7-8.5 8.5-5-5L2 17"/>',
+};
+
+export function DwIcon({ name, size = 18, stroke = 2, className, style }) {
+	const inner = DW_ICONS[name];
+	if (!inner) return null;
+	return (
+		<svg
+			width={size}
+			height={size}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth={stroke}
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			className={className}
+			style={style}
+			dangerouslySetInnerHTML={{ __html: inner }}
+		/>
+	);
+}
+
+const SIGNUP = "https://my.dawarich.app/users/sign_up?utm_source=site&utm_medium=pricing";
+
+export const PLANS = {
+	lite: {
+		key: "lite",
+		name: "Lite",
+		tagline: "A private alternative to Google Timeline for casual trackers.",
+		icon: "map-pin",
+		accent: "blue",
+		oldPrice: "59.99",
+		price: "49.99",
+		period: "/year",
+		perMonth: "€4.17/month",
+		perDay: "€0.14/day",
+		badge: null,
+		cta: "Try Lite Free",
+		ctaStyle: "outline",
+		href: `${SIGNUP}&utm_campaign=try7dayslite&plan=lite`,
+		footnote: "Annual only · Cancel anytime",
+		urgency: "Prices will be increased soon — lock in €49.99 today",
+		featuresHeading: null,
+		features: [
+			{ icon: "smartphone", label: "iOS & Android native apps" },
+			{ icon: "map-pin", label: "Background location tracking" },
+			{ icon: "calendar", label: "12 months of searchable history" },
+			{ icon: "arrow-down-up", label: "Unlimited imports & exports" },
+			{ icon: "map", label: "Interactive map with routes" },
+			{ icon: "route", label: "Speed-colored routes & daily replay" },
+			{ icon: "flag", label: "Trips & places management" },
+			{ icon: "chart-column", label: "Basic stats & monthly breakdowns" },
+			{ icon: "zap", label: "200 req/hr API rate limit" },
+		],
+	},
+	pro: {
+		key: "pro",
+		name: "Pro",
+		tagline: "Unlimited history, advanced visualizations, and full API access.",
+		icon: "crown",
+		accent: "blue",
+		oldPrice: "179.99",
+		price: "119.99",
+		priceMonthly: "17.99",
+		period: "/year",
+		periodMonthly: "/month",
+		perMonth: "€10.00/month",
+		perDay: "€0.33/day",
+		perDayMonthly: "€0.60/day",
+		save: "Save 44%",
+		badge: "MOST POPULAR",
+		cta: "Start Pro Free — 7 Days",
+		ctaStyle: "primary",
+		href: `${SIGNUP}&utm_campaign=try7days`,
+		footnote: "Cancel anytime",
+		urgency: "Prices will be increased soon — lock in €119.99 today",
+		featuresHeading: "Everything in Lite, plus:",
+		features: [
+			{ icon: "infinity", label: "Unlimited data history — forever" },
+			{ icon: "flame", label: "Heatmap & Fog of War layers" },
+			{ icon: "globe", label: "Globe view (3D)" },
+			{ icon: "camera", label: "Trip photo integration" },
+			{ icon: "layers", label: "Immich / PhotoPrism integration" },
+			{ icon: "share", label: "Full year-in-review & public sharing" },
+			{ icon: "square-pen", label: "Full Write API access" },
+			{ icon: "zap", label: "1,000 req/hr API rate limit" },
+		],
+	},
+	family: {
+		key: "family",
+		name: "Family",
+		tagline: "Every Pro feature for the whole household — one annual subscription, up to 5 people.",
+		icon: "users",
+		accent: "teal",
+		badge: "COMING SOON",
+		urgency: null,
+		waitlistListId: "dawarichfamilywaitlist",
+		featuresHeading: "Everything in Pro, plus:",
+		features: [
+			{ icon: "users", label: "Up to 5 members on one subscription" },
+			{ icon: "badge-check", label: "Each member gets full Pro access" },
+			{ icon: "map-pin-plus", label: "Invite or remove members anytime" },
+			{ icon: "shield-check", label: "Members inherit access while in the family" },
+			{ icon: "map-pin", label: "Real-time family location sharing" },
+		],
+	},
+};
+
+export const COMPARE_GROUPS = [
+	{
+		name: "Tracking & apps",
+		rows: [
+			{ label: "iOS & Android native apps", lite: true, pro: true, family: true },
+			{ label: "Background location tracking", lite: true, pro: true, family: true },
+			{ label: "Real-time family location sharing", lite: false, pro: false, family: true },
+		],
+	},
+	{
+		name: "History & data",
+		rows: [
+			{ label: "Searchable history", lite: "12 months", pro: "Unlimited", family: "Unlimited" },
+			{ label: "Unlimited imports & exports", lite: true, pro: true, family: true },
+			{ label: "Data is always yours (export anytime)", lite: true, pro: true, family: true },
+		],
+	},
+	{
+		name: "Maps & visualization",
+		rows: [
+			{ label: "Interactive map with routes", lite: true, pro: true, family: true },
+			{ label: "Speed-colored routes & daily replay", lite: true, pro: true, family: true },
+			{ label: "Heatmap & Fog of War layers", lite: false, pro: true, family: true },
+			{ label: "Globe view (3D)", lite: false, pro: true, family: true },
+			{ label: "Trip photo integration", lite: false, pro: true, family: true },
+			{ label: "Immich / PhotoPrism integration", lite: false, pro: true, family: true },
+		],
+	},
+	{
+		name: "Insights & sharing",
+		rows: [
+			{ label: "Basic stats & monthly breakdowns", lite: true, pro: true, family: true },
+			{ label: "Full year-in-review & public sharing", lite: false, pro: true, family: true },
+			{ label: "Trips & places management", lite: true, pro: true, family: true },
+		],
+	},
+	{
+		name: "API & limits",
+		rows: [
+			{ label: "API rate limit", lite: "200 req/hr", pro: "1,000 req/hr", family: "1,000 req/hr" },
+			{ label: "Full Write API access", lite: false, pro: true, family: true },
+		],
+	},
+	{
+		name: "Members & billing",
+		rows: [
+			{ label: "Members on one subscription", lite: "1", pro: "1", family: "Up to 5" },
+			{ label: "Each member gets full Pro access", lite: false, pro: false, family: true },
+			{ label: "14-day money-back guarantee", lite: true, pro: true, family: true },
+		],
+	},
+];

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -3,6 +3,7 @@ import Head from "@docusaurus/Head";
 import Layout from "@theme/Layout";
 import { initializePaddle } from "@paddle/paddle-js";
 import PricingSection from "@site/src/components/PricingSection";
+import PricingCompare from "@site/src/components/PricingCompare";
 import FAQ from "@site/src/components/FAQ";
 
 export default function PricingPage() {
@@ -85,6 +86,7 @@ export default function PricingPage() {
 
 			<main>
 				<PricingSection />
+				<PricingCompare />
 				<FAQ />
 			</main>
 		</Layout>


### PR DESCRIPTION
Implements the Claude Design handoffs for the pricing section, plus the Family waitlist and the Google Timeline vs Dawarich table.

## What changed

**Pricing cards** (`PricingCard`, `PricingSection`, `pricingPlans.js`)
- Refined redesign, light + dark via `[data-theme]`: per-feature Lucide icon chips, plan-icon header, struck old price + **Save 44%** badge, Pro **Monthly/Annual** toggle (live price), amber lock-in banner, teal per-day pill, per-card guarantee, glowing/elevated Pro, de-emphasized Family.
- Cards now driven from a shared `PLANS` data module.

**Feature comparison matrix** (`PricingCompare`, new, on `/pricing`)
- Interactive: expand/collapse sections + **Highlight differences**. Its own UTM tagging (`utm_medium=pricing_compare`, per-plan `utm_content`).

**Family → waitlist** (`WaitlistForm`, new)
- Removed the price entirely; added an **email-only** Notifuse signup (`list_ids=["dawarichfamilywaitlist"]`), same approach as the newsletter form.

**Google Timeline vs Dawarich** (`Comparison`)
- Restyled to match: glowing Dawarich column (accent bar + map-grid wash), tinted check/x/minus chips, branded header, "Switch to Dawarich" CTA. Content unchanged.

**Guarantee banner**
- Rewritten into a concierge-import risk-reversal: _"Import your Google Timeline in 10 minutes — or let us do it for you, free."_ + 14-day money-back.

## Pricing math (verified)
- Lite €4.17/mo (49.99÷12), €0.14/day (49.99÷365)
- Pro €10.00/mo (119.99÷12), €0.33/day annual / **€0.60/day monthly** (pill now tracks the toggle)
- Save 44% = 1 − 119.99 ÷ (17.99×12)

## Test plan
- [x] `npm run build` passes
- [x] Cards + comparison + versus table render in light **and** dark
- [x] Pro monthly/annual toggle updates price + per-day
- [x] Highlight-differences filters rows
- [x] Waitlist client-side validation (no live test contact created)

Note: base is `feature/family-plan-pricing` so the diff is just the pricing redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)