### PR TITLE
Redesign How It Works as a GPS route with map-pin steps

### DIFF
--- a/src/components/HowItWorks.js
+++ b/src/components/HowItWorks.js
@@ -1,6 +1,119 @@
+import { useEffect, useState } from 'react';
 import styles from './HowItWorks.module.css';
 
-export default function HowItWorks({ title, subtitle, steps, horizontal }) {
+const ROUTE_PINS = [
+  { left: '16.63%', top: '50%' },
+  { left: '50%', top: '40%' },
+  { left: '83.37%', top: '53.3%', accent: true },
+];
+
+function Pin({ icon, num, accent, className }) {
+  return (
+    <div className={`${styles.pinBody} ${accent ? styles.pinBodyAccent : ''} ${className || ''}`}>
+      {icon && <span className={styles.pinIcon}>{icon}</span>}
+      <span className={styles.pinNum}>{num}</span>
+    </div>
+  );
+}
+
+function RouteHowItWorks({ title, subtitle, steps }) {
+  const [animate, setAnimate] = useState(true);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => setAnimate(!mq.matches);
+    update();
+    mq.addEventListener('change', update);
+    return () => mq.removeEventListener('change', update);
+  }, []);
+
+  const pinFor = (index) =>
+    ROUTE_PINS[index] || { left: `${((index + 0.5) / steps.length) * 100}%`, top: '50%' };
+
+  return (
+    <section className={styles.howItWorks}>
+      <div className={styles.container}>
+        {title && <h2 className={styles.title}>{title}</h2>}
+        {subtitle && <p className={styles.subtitle}>{subtitle}</p>}
+
+        <div className={styles.routeWrap}>
+          <div className={styles.routeBand} aria-hidden="true">
+            <svg
+              className={styles.routeSvg}
+              viewBox="0 0 980 300"
+              fill="none"
+              preserveAspectRatio="xMidYMid meet"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                id="hiw-route-path"
+                d="M163,150 C 260,90 380,92 490,120 C 620,153 700,210 817,160"
+                stroke="var(--ifm-color-primary)"
+                strokeWidth="3.5"
+                strokeLinecap="round"
+                strokeDasharray="2 11"
+                opacity="0.85"
+              />
+              {animate && (
+                <>
+                  <circle r="11" fill="var(--ifm-color-accent)" opacity="0.25">
+                    <animateMotion dur="6s" repeatCount="indefinite">
+                      <mpath href="#hiw-route-path" />
+                    </animateMotion>
+                  </circle>
+                  <circle r="6" fill="var(--ifm-color-accent)">
+                    <animateMotion dur="6s" repeatCount="indefinite" rotate="auto">
+                      <mpath href="#hiw-route-path" />
+                    </animateMotion>
+                  </circle>
+                </>
+              )}
+            </svg>
+
+            {steps.map((step, index) => {
+              const pin = pinFor(index);
+              return (
+                <div
+                  key={index}
+                  className={styles.routePin}
+                  style={{ left: pin.left, top: pin.top }}
+                >
+                  <Pin icon={step.icon} num={index + 1} accent={pin.accent} />
+                </div>
+              );
+            })}
+          </div>
+
+          <div className={styles.routeSteps}>
+            {steps.map((step, index) => (
+              <div key={index} className={styles.routeStep}>
+                <Pin
+                  icon={step.icon}
+                  num={index + 1}
+                  accent={pinFor(index).accent}
+                  className={styles.routeStepPinMobile}
+                />
+                <p className={styles.routeKicker}>
+                  Step {String(index + 1).padStart(2, '0')}
+                </p>
+                <h3 className={styles.routeStepTitle}>{step.title}</h3>
+                {step.description && (
+                  <p className={styles.routeStepDesc}>{step.description}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function HowItWorks({ title, subtitle, steps, horizontal, variant }) {
+  if (variant === 'route') {
+    return <RouteHowItWorks title={title} subtitle={subtitle} steps={steps} />;
+  }
+
   return (
     <section className={styles.howItWorks}>
       <div className={styles.container}>

--- a/src/components/HowItWorks.module.css
+++ b/src/components/HowItWorks.module.css
@@ -234,3 +234,201 @@
   color: var(--ifm-color-primary);
   font-weight: 700;
 }
+
+/* ============================================================
+   variant="route" — GPS route & pins
+   The three steps become stops on a tracked route: a dashed
+   path with map-pin nodes, a faint ghosted map behind, and a
+   dot that replays along the path.
+   ============================================================ */
+.routeWrap {
+  margin-top: 3rem;
+  position: relative;
+}
+
+.routeBand {
+  position: relative;
+  width: 100%;
+  max-width: 980px;
+  aspect-ratio: 980 / 300;
+  margin: 0 auto;
+}
+
+.routeBand::before {
+  content: '';
+  position: absolute;
+  inset: -24px -40px;
+  background-image: url('/img/the_map.png');
+  background-size: cover;
+  background-position: center 38%;
+  filter: grayscale(1) contrast(0.9);
+  opacity: 0.1;
+  -webkit-mask-image: radial-gradient(ellipse 75% 80% at 50% 45%, #000 35%, transparent 78%);
+  mask-image: radial-gradient(ellipse 75% 80% at 50% 45%, #000 35%, transparent 78%);
+  pointer-events: none;
+}
+
+[data-theme='dark'] .routeBand::before {
+  opacity: 0.14;
+  filter: grayscale(1) contrast(1.1) brightness(0.9);
+}
+
+.routeSvg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+.routePin {
+  position: absolute;
+  transform: translate(-50%, -100%);
+}
+
+.pinBody {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  border-radius: 50% 50% 50% 0;
+  transform: rotate(-45deg);
+  background: var(--ifm-color-primary);
+  box-shadow: 0 6px 16px rgba(59, 130, 246, 0.4), 0 2px 4px rgba(0, 0, 0, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 3px solid #fff;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.pinBodyAccent {
+  background: var(--ifm-color-accent);
+  box-shadow: 0 6px 16px rgba(20, 184, 166, 0.4), 0 2px 4px rgba(0, 0, 0, 0.15);
+}
+
+.routePin:hover .pinBody {
+  transform: rotate(-45deg) scale(1.06);
+  box-shadow: 0 10px 22px rgba(59, 130, 246, 0.45), 0 2px 6px rgba(0, 0, 0, 0.18);
+}
+
+.routePin:hover .pinBodyAccent {
+  box-shadow: 0 10px 22px rgba(20, 184, 166, 0.45), 0 2px 6px rgba(0, 0, 0, 0.18);
+}
+
+.pinIcon {
+  transform: rotate(45deg);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pinIcon svg {
+  width: 24px;
+  height: 24px;
+}
+
+.pinNum {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #fff;
+  color: #1a1a1a;
+  font-size: 0.72rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+  transform: rotate(45deg);
+}
+
+.routeSteps {
+  display: flex;
+  width: 100%;
+  max-width: 980px;
+  margin: 18px auto 0;
+}
+
+.routeStep {
+  flex: 1;
+  text-align: center;
+  padding: 0 24px;
+}
+
+.routeKicker {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ifm-color-primary);
+  margin: 0 0 6px;
+}
+
+.routeStepTitle {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0 0 10px;
+  color: var(--ifm-heading-color);
+}
+
+.routeStepDesc {
+  font-size: 0.98rem;
+  line-height: 1.6;
+  color: var(--ifm-color-emphasis-700);
+  margin: 0;
+}
+
+[data-theme='dark'] .routeStepDesc {
+  color: var(--ifm-color-emphasis-600);
+}
+
+.routeStepDesc a {
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.routeStepDesc a:hover {
+  text-decoration: underline;
+}
+
+/* Per-step pin marker: hidden on desktop (the band carries the pins),
+   shown above each step when the band collapses on mobile. Compound
+   selector keeps specificity above .pinBody regardless of bundle order. */
+.pinBody.routeStepPinMobile {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .routeBand {
+    display: none;
+  }
+
+  .routeSteps {
+    flex-direction: column;
+    gap: 2.5rem;
+    margin-top: 1rem;
+  }
+
+  .routeStep {
+    padding: 0;
+  }
+
+  .pinBody.routeStepPinMobile {
+    display: flex;
+    margin: 0 auto 1.25rem;
+  }
+
+  .routeStepTitle {
+    font-size: 1.25rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pinBody {
+    transition: none;
+  }
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -238,7 +238,7 @@ export default function Home() {
 					title="How It Works"
 					subtitle="Get started in three simple steps."
 					steps={howItWorksSteps}
-					horizontal
+					variant="route"
 				/>
 				<Features />
 				<CTABanner />


### PR DESCRIPTION
## What

Redesigns the homepage **How It Works** section. The three icon-in-circle steps are replaced with the product's own metaphor — the steps become stops on a tracked route:

- a dashed GPS route with **map-pin nodes** (icon + number badge) for each step,
- a faint **ghosted map** (`the_map.png`) behind the path,
- a **replay dot** that travels the route (the same "replay" magic the hero video shows).

**Content is unchanged** — same three steps (Track / Visualize / Remember), same copy. This is a visuals-only treatment.

## How

- Added as an **opt-in `variant="route"`** on the shared `HowItWorks` component. The default and `horizontal` render paths are untouched, so the ~10 other pages that reuse this component (statistics, integrations, trips, etc.) are unaffected.
- Only the homepage (`src/pages/index.js`) opts in.
- Uses existing design tokens (`--ifm-color-primary` blue, `--ifm-color-accent` teal).
- Dark-theme overrides, a mobile stacked layout (route band collapses, per-step pins stack), and a `prefers-reduced-motion` guard for the animated dot.

## Source

Implements **Direction 1 ("GPS route & pins")** from the Claude Design handoff `How It Works Concepts.html` — the direction recommended in the design session.

## Verification

- `npm run build` passes (clean off `main`).
- Verified rendering in a browser: desktop light, desktop dark, and mobile (390px).
- Caught and fixed a prod-only cssnano bug where a single-class `display:none` for the mobile pins was overridden by `.pinBody` — fixed with a compound `.pinBody.routeStepPinMobile` selector.

## Notes

- `prefers-reduced-motion` disables the replay dot.