### PR TITLE
Save to my Dawarich account — tools → signup handoff (frontend)

### DIFF
--- a/src/components/FileUploader.js
+++ b/src/components/FileUploader.js
@@ -35,6 +35,7 @@ export default function FileUploader({ onFilesLoaded, onClear }) {
           filename: file.name,
           data: json,
           size: file.size,
+          blob: file,
         });
       }
 

--- a/src/components/SaveToAccountButton.js
+++ b/src/components/SaveToAccountButton.js
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import styles from './SaveToAccountButton.module.css';
 
 const API_BASE = 'https://my.dawarich.app';
+const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
 
 const ERROR_MESSAGES = {
   413: 'Your file is too large for instant import. Sign up first, then upload from your dashboard.',
@@ -9,19 +10,42 @@ const ERROR_MESSAGES = {
   default: 'Upload failed. Please try again.',
 };
 
+function trackEvent(name) {
+  if (typeof window !== 'undefined' && typeof window.sa_event === 'function') {
+    window.sa_event(name);
+  }
+}
+
 export default function SaveToAccountButton({ toolName, sourceHint, getFiles, disabled }) {
+  const busyRef = useRef(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState(null);
 
   const handleClick = async () => {
+    if (busyRef.current) return;
+    busyRef.current = true;
     setBusy(true);
     setError(null);
+    trackEvent(`handoff_click_${toolName}`);
+
+    const fail = (message) => {
+      trackEvent(`handoff_error_${toolName}`);
+      setError(message);
+      busyRef.current = false;
+      setBusy(false);
+    };
 
     try {
       const files = await getFiles();
       if (!files || files.length === 0) {
-        setError('No files to save. Upload a file first.');
-        return;
+        return fail('No files to save. Upload a file first.');
+      }
+
+      // Check the raw total before zipping: compression won't rescue a
+      // multi-hundred-MB Takeout, and JSZip would freeze the tab trying.
+      const totalBytes = files.reduce((sum, f) => sum + (f.blob?.size || 0), 0);
+      if (totalBytes > MAX_UPLOAD_BYTES) {
+        return fail(ERROR_MESSAGES[413]);
       }
 
       const { bundleFiles } = await import('@site/src/utils/bundleFiles');
@@ -42,16 +66,19 @@ export default function SaveToAccountButton({ toolName, sourceHint, getFiles, di
 
       if (response.status === 201) {
         const data = await response.json();
-        window.location.href = `${data.claim_url}&utm_campaign=${encodeURIComponent(toolName)}`;
+        const claimUrl = new URL(data.claim_url);
+        claimUrl.searchParams.set('utm_campaign', toolName);
+        trackEvent(`handoff_success_${toolName}`);
+        // Deliberately stay busy: re-enabling before navigation completes
+        // would let a second click create a duplicate pending import.
+        window.location.href = claimUrl.toString();
         return;
       }
 
-      setError(ERROR_MESSAGES[response.status] || ERROR_MESSAGES.default);
+      fail(ERROR_MESSAGES[response.status] || ERROR_MESSAGES.default);
     } catch (e) {
       console.error('[SaveToAccountButton] Upload failed:', e);
-      setError(ERROR_MESSAGES.default);
-    } finally {
-      setBusy(false);
+      fail(ERROR_MESSAGES.default);
     }
   };
 

--- a/src/components/SaveToAccountButton.js
+++ b/src/components/SaveToAccountButton.js
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import styles from './SaveToAccountButton.module.css';
+
+const API_BASE = 'https://my.dawarich.app';
+
+const ERROR_MESSAGES = {
+  413: 'Your file is too large for instant import. Sign up first, then upload from your dashboard.',
+  429: 'Too many uploads from your network. Please try again in an hour.',
+  default: 'Upload failed. Please try again.',
+};
+
+export default function SaveToAccountButton({ toolName, sourceHint, getFiles, disabled }) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleClick = async () => {
+    setBusy(true);
+    setError(null);
+
+    try {
+      const files = await getFiles();
+      if (!files || files.length === 0) {
+        setError('No files to save. Upload a file first.');
+        return;
+      }
+
+      const { bundleFiles } = await import('@site/src/utils/bundleFiles');
+      const bundle = await bundleFiles(files);
+      const originalFilename = files.length === 1 ? `${files[0].name}.zip` : bundle.filename;
+
+      const form = new FormData();
+      form.append('file', bundle.blob, originalFilename);
+      form.append('original_filename', originalFilename);
+      if (sourceHint) {
+        form.append('source_hint', sourceHint);
+      }
+
+      const response = await fetch(`${API_BASE}/api/v1/imports/pending`, {
+        method: 'POST',
+        body: form,
+      });
+
+      if (response.status === 201) {
+        const data = await response.json();
+        window.location.href = `${data.claim_url}&utm_campaign=${encodeURIComponent(toolName)}`;
+        return;
+      }
+
+      setError(ERROR_MESSAGES[response.status] || ERROR_MESSAGES.default);
+    } catch (e) {
+      console.error('[SaveToAccountButton] Upload failed:', e);
+      setError(ERROR_MESSAGES.default);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <button
+        type="button"
+        className={styles.button}
+        onClick={handleClick}
+        disabled={disabled || busy}
+      >
+        <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" width="18" height="18">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"
+          />
+        </svg>
+        {busy ? 'Uploading…' : 'Save to my Dawarich account'}
+      </button>
+      {error && <p className={styles.error}>{error}</p>}
+    </div>
+  );
+}

--- a/src/components/SaveToAccountButton.js
+++ b/src/components/SaveToAccountButton.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styles from './SaveToAccountButton.module.css';
 
 const API_BASE = 'https://my.dawarich.app';
@@ -9,6 +9,22 @@ const ERROR_MESSAGES = {
   429: 'Too many uploads from your network. Please try again in an hour.',
   default: 'Upload failed. Please try again.',
 };
+
+/**
+ * Dark-launch gate: the save-to-account UI only renders when the page is
+ * opened with ?handoff=1 (checked client-side after hydration, so SSR and
+ * first paint match). Lets the site deploy ahead of the backend endpoint
+ * and enables testing against production before the public rollout.
+ */
+export function useHandoffEnabled() {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    setEnabled(new URLSearchParams(window.location.search).has('handoff'));
+  }, []);
+
+  return enabled;
+}
 
 function trackEvent(name) {
   if (typeof window !== 'undefined' && typeof window.sa_event === 'function') {

--- a/src/components/SaveToAccountButton.js
+++ b/src/components/SaveToAccountButton.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import styles from './SaveToAccountButton.module.css';
 
-const API_BASE = 'https://my.dawarich.app';
+const API_BASE = 'https://staging.dawarich.app';
 const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
 
 const ERROR_MESSAGES = {

--- a/src/components/SaveToAccountButton.module.css
+++ b/src/components/SaveToAccountButton.module.css
@@ -1,0 +1,38 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--ifm-color-primary);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0.875rem 2rem;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.button:hover:not(:disabled) {
+  background: var(--ifm-color-primary-dark);
+  transform: translateY(-1px);
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.error {
+  color: var(--ifm-color-danger);
+  font-size: 0.875rem;
+  margin: 0;
+  text-align: center;
+}

--- a/src/pages/tools/google-timeline-converter.js
+++ b/src/pages/tools/google-timeline-converter.js
@@ -12,7 +12,7 @@ import { detectGoogleSource } from '@site/src/utils/detectGoogleSource';
 import styles from './google-timeline-converter.module.css';
 
 const pageTitle = "Google Timeline to GPX/KML/CSV Converter - Convert Location History Free";
-const pageDescription = "Free, privacy-first converter for Google Timeline data. Convert your location history to GPX, KML, GeoJSON, or CSV format. All processing in your browser — no data uploaded.";
+const pageDescription = "Free, privacy-first converter for Google Timeline data. Convert your location history to GPX, KML, GeoJSON, or CSV format. All processing in your browser.";
 const pageUrl = "https://dawarich.app/tools/google-timeline-converter/";
 const imageUrl = "https://dawarich.app/img/meta-image.png";
 
@@ -29,7 +29,7 @@ const FORMAT_LABELS = {
 const faqItems = [
   {
     question: "Is it safe to upload my Google Timeline data?",
-    answer: "Yes. All data processing happens entirely in your browser using JavaScript. Your location history files are never uploaded to any server — they stay on your device. When you close the tab, the data is gone. There is no backend, no cookies tracking your files, and no analytics on your location data. The tool is also open source, so you can verify the code yourself."
+    answer: "Yes. All conversion happens entirely in your browser using JavaScript — your files stay on your device and are gone when you close the tab. There are no cookies tracking your files and no analytics on your location data. The only exception is the optional “Save to my Dawarich account” button, which uploads your file to Dawarich Cloud so it can be imported into your new account. The tool is open source, so you can verify the code yourself."
   },
   {
     question: "What Google Timeline formats can I convert?",
@@ -381,7 +381,7 @@ export default function GoogleTimelineConverter() {
                     </svg>
                     Privacy First
                   </strong>
-                  <p>All data processing happens entirely in your browser. Your location data never leaves your device and is not sent to any server.</p>
+                  <p>All conversion happens entirely in your browser — your location data stays on your device unless you choose “Save to my Dawarich account.”</p>
                 </div>
               </div>
             </div>
@@ -537,7 +537,7 @@ export default function GoogleTimelineConverter() {
             <div className={styles.infoCard}>
               <h2>What Is a Google Timeline Converter?</h2>
               <p>A Google Timeline converter takes the raw JSON files from your Google location history export and transforms them into standard GPS formats that are widely supported by mapping applications, fitness trackers, and geographic information systems. Instead of being locked into Google's proprietary JSON format, you get files that work everywhere.</p>
-              <p>This tool processes everything in your browser, so your sensitive location data never leaves your device. Upload your files, pick your formats, and download — it takes seconds for most exports and handles files with hundreds of thousands of location points.</p>
+              <p>This tool converts everything in your browser, so downloading your formats never sends your location data anywhere. Upload your files, pick your formats, and download — it takes seconds for most exports and handles files with hundreds of thousands of location points. (If you use “Save to my Dawarich account,” that one action uploads your file to Dawarich Cloud to set up your import — nothing is sent otherwise.)</p>
             </div>
 
             <div className={styles.infoCard}>

--- a/src/pages/tools/google-timeline-converter.js
+++ b/src/pages/tools/google-timeline-converter.js
@@ -7,6 +7,8 @@ import { timelineToConverterPoints, timelineToCSV } from '@site/src/utils/timeli
 import { toGPX, toGeoJSON, toKML, toKMZ } from '@site/src/utils/formatConverters';
 import PersonalizedCTA from '@site/src/components/PersonalizedCTA';
 import RelatedTools from '@site/src/components/RelatedTools';
+import SaveToAccountButton from '@site/src/components/SaveToAccountButton';
+import { detectGoogleSource } from '@site/src/utils/detectGoogleSource';
 import styles from './google-timeline-converter.module.css';
 
 const pageTitle = "Google Timeline to GPX/KML/CSV Converter - Convert Location History Free";
@@ -158,6 +160,11 @@ export default function GoogleTimelineConverter() {
   const handleFormatToggle = useCallback((format) => {
     setSelectedFormats(prev => ({ ...prev, [format]: !prev[format] }));
   }, []);
+
+  const getOriginalFiles = useCallback(
+    () => uploadedFiles.map((f) => ({ name: f.filename, blob: f.blob })),
+    [uploadedFiles]
+  );
 
   const handleDownload = useCallback(async (format) => {
     if (allPoints.length === 0 && allPaths.length === 0) return;
@@ -496,6 +503,18 @@ export default function GoogleTimelineConverter() {
                         {isConverting ? 'Converting...' : `Download All Selected (${selectedCount})`}
                       </button>
                     )}
+                  </div>
+
+                  <div className={styles.saveToAccountSection}>
+                    <p className={styles.saveToAccountIntro}>
+                      Want this in your Dawarich account too? We'll import it during signup — no second upload needed.
+                    </p>
+                    <SaveToAccountButton
+                      toolName="google-timeline-converter"
+                      sourceHint={detectGoogleSource(parsedResults)}
+                      getFiles={getOriginalFiles}
+                      disabled={!hasData}
+                    />
                   </div>
                 </>
               )}

--- a/src/pages/tools/google-timeline-converter.js
+++ b/src/pages/tools/google-timeline-converter.js
@@ -7,7 +7,7 @@ import { timelineToConverterPoints, timelineToCSV } from '@site/src/utils/timeli
 import { toGPX, toGeoJSON, toKML, toKMZ } from '@site/src/utils/formatConverters';
 import PersonalizedCTA from '@site/src/components/PersonalizedCTA';
 import RelatedTools from '@site/src/components/RelatedTools';
-import SaveToAccountButton from '@site/src/components/SaveToAccountButton';
+import SaveToAccountButton, { useHandoffEnabled } from '@site/src/components/SaveToAccountButton';
 import { detectGoogleSource } from '@site/src/utils/detectGoogleSource';
 import styles from './google-timeline-converter.module.css';
 
@@ -94,6 +94,7 @@ function formatDateRange(points, paths) {
 }
 
 export default function GoogleTimelineConverter() {
+  const handoffEnabled = useHandoffEnabled();
   const [uploadedFiles, setUploadedFiles] = useState([]);
   const [parsedResults, setParsedResults] = useState([]);
   const [allPoints, setAllPoints] = useState([]);
@@ -505,17 +506,19 @@ export default function GoogleTimelineConverter() {
                     )}
                   </div>
 
-                  <div className={styles.saveToAccountSection}>
-                    <p className={styles.saveToAccountIntro}>
-                      Want this in your Dawarich account too? We'll import it during signup — no second upload needed.
-                    </p>
-                    <SaveToAccountButton
-                      toolName="google-timeline-converter"
-                      sourceHint={detectGoogleSource(parsedResults)}
-                      getFiles={getOriginalFiles}
-                      disabled={!hasData}
-                    />
-                  </div>
+                  {handoffEnabled && (
+                    <div className={styles.saveToAccountSection}>
+                      <p className={styles.saveToAccountIntro}>
+                        Want this in your Dawarich account too? We'll import it during signup — no second upload needed.
+                      </p>
+                      <SaveToAccountButton
+                        toolName="google-timeline-converter"
+                        sourceHint={detectGoogleSource(parsedResults)}
+                        getFiles={getOriginalFiles}
+                        disabled={!hasData}
+                      />
+                    </div>
+                  )}
                 </>
               )}
 

--- a/src/pages/tools/google-timeline-converter.module.css
+++ b/src/pages/tools/google-timeline-converter.module.css
@@ -332,6 +332,21 @@
   margin-bottom: 2rem;
 }
 
+/* Save-to-account handoff */
+.saveToAccountSection {
+  margin-bottom: 2rem;
+  padding: 1.5rem;
+  border: 1px dashed var(--ifm-color-primary);
+  border-radius: 8px;
+  text-align: center;
+}
+
+.saveToAccountIntro {
+  margin: 0 0 1rem;
+  font-size: 0.95rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
 .downloadButtons {
   display: flex;
   flex-wrap: wrap;

--- a/src/pages/tools/gpx-merger.js
+++ b/src/pages/tools/gpx-merger.js
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from 'react';
+import SaveToAccountButton from '@site/src/components/SaveToAccountButton';
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 import { parseGPXDetailed, mergeGPXFiles, calculateMergeStats } from '@site/src/utils/gpxMerger';
@@ -124,6 +125,14 @@ export default function GPXMerger() {
       setError(`Error merging files: ${err.message}`);
     }
   };
+
+  const getMergedFile = useCallback(async () => {
+    if (parsedFiles.length < 2) return [];
+
+    const mergedGpx = mergeGPXFiles(parsedFiles, options);
+    const name = `${options.outputName.replace(/[^a-z0-9]/gi, '_')}.gpx`;
+    return [{ name, blob: new Blob([mergedGpx], { type: 'application/gpx+xml' }) }];
+  }, [parsedFiles, options]);
 
   const moveFile = (index, direction) => {
     const newIndex = index + direction;
@@ -354,6 +363,18 @@ export default function GPXMerger() {
                 </svg>
                 Merge & Download GPX
               </button>
+
+              <div className={styles.saveToAccountSection}>
+                <p className={styles.saveToAccountIntro}>
+                  Or skip the download — we'll merge and import it into your Dawarich account during signup.
+                </p>
+                <SaveToAccountButton
+                  toolName="gpx-merger"
+                  sourceHint="gpx"
+                  getFiles={getMergedFile}
+                  disabled={files.length < 2}
+                />
+              </div>
             </div>
           )}
 

--- a/src/pages/tools/gpx-merger.js
+++ b/src/pages/tools/gpx-merger.js
@@ -8,7 +8,7 @@ import RelatedTools from '@site/src/components/RelatedTools';
 import styles from './gpx-merger.module.css';
 
 const pageTitle = "Free GPX Merger - Combine Multiple GPS Track Files Online";
-const pageDescription = "Merge multiple GPX files into one. Free, privacy-first online tool to combine GPS tracks, waypoints, and routes. Works entirely in your browser - no upload required.";
+const pageDescription = "Merge multiple GPX files into one. Free, privacy-first online tool to combine GPS tracks, waypoints, and routes. Works entirely in your browser.";
 const pageUrl = "https://dawarich.app/tools/gpx-merger/";
 const imageUrl = "https://dawarich.app/img/meta-image.png";
 
@@ -130,7 +130,8 @@ export default function GPXMerger() {
     if (parsedFiles.length < 2) return [];
 
     const mergedGpx = mergeGPXFiles(parsedFiles, options);
-    const name = `${options.outputName.replace(/[^a-z0-9]/gi, '_')}.gpx`;
+    const sanitized = options.outputName.replace(/[^a-z0-9]/gi, '_');
+    const name = `${sanitized || 'merged_tracks'}.gpx`;
     return [{ name, blob: new Blob([mergedGpx], { type: 'application/gpx+xml' }) }];
   }, [parsedFiles, options]);
 
@@ -382,7 +383,7 @@ export default function GPXMerger() {
             <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" width="20" height="20">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
             </svg>
-            <span>Your files stay in your browser. Nothing is uploaded to any server.</span>
+            <span>Merging happens in your browser. Nothing is uploaded unless you choose “Save to my Dawarich account.”</span>
           </div>
         </div>
 

--- a/src/pages/tools/gpx-merger.js
+++ b/src/pages/tools/gpx-merger.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import SaveToAccountButton from '@site/src/components/SaveToAccountButton';
+import SaveToAccountButton, { useHandoffEnabled } from '@site/src/components/SaveToAccountButton';
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 import { parseGPXDetailed, mergeGPXFiles, calculateMergeStats } from '@site/src/utils/gpxMerger';
@@ -13,6 +13,7 @@ const pageUrl = "https://dawarich.app/tools/gpx-merger/";
 const imageUrl = "https://dawarich.app/img/meta-image.png";
 
 export default function GPXMerger() {
+  const handoffEnabled = useHandoffEnabled();
   const [files, setFiles] = useState([]);
   const [parsedFiles, setParsedFiles] = useState([]);
   const [stats, setStats] = useState(null);
@@ -365,17 +366,19 @@ export default function GPXMerger() {
                 Merge & Download GPX
               </button>
 
-              <div className={styles.saveToAccountSection}>
-                <p className={styles.saveToAccountIntro}>
-                  Or skip the download — we'll merge and import it into your Dawarich account during signup.
-                </p>
-                <SaveToAccountButton
-                  toolName="gpx-merger"
-                  sourceHint="gpx"
-                  getFiles={getMergedFile}
-                  disabled={files.length < 2}
-                />
-              </div>
+              {handoffEnabled && (
+                <div className={styles.saveToAccountSection}>
+                  <p className={styles.saveToAccountIntro}>
+                    Or skip the download — we'll merge and import it into your Dawarich account during signup.
+                  </p>
+                  <SaveToAccountButton
+                    toolName="gpx-merger"
+                    sourceHint="gpx"
+                    getFiles={getMergedFile}
+                    disabled={files.length < 2}
+                  />
+                </div>
+              )}
             </div>
           )}
 

--- a/src/pages/tools/gpx-merger.module.css
+++ b/src/pages/tools/gpx-merger.module.css
@@ -446,3 +446,18 @@
   margin-bottom: 0.4rem;
 }
 
+
+/* Save-to-account handoff */
+.saveToAccountSection {
+  margin-top: 1rem;
+  padding: 1.25rem;
+  border: 1px dashed var(--ifm-color-primary);
+  border-radius: 8px;
+  text-align: center;
+}
+
+.saveToAccountIntro {
+  margin: 0 0 1rem;
+  font-size: 0.95rem;
+  color: var(--ifm-color-emphasis-700);
+}

--- a/src/pages/tools/heatmap-generator.js
+++ b/src/pages/tools/heatmap-generator.js
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
+import SaveToAccountButton from '@site/src/components/SaveToAccountButton';
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 import BrowserOnly from '@docusaurus/BrowserOnly';
@@ -358,6 +359,7 @@ export default function HeatmapGenerator() {
           processedFiles.push({
             name: file.name,
             pointCount: filePoints.length,
+            blob: file,
           });
         } catch (err) {
           console.error(`Error parsing ${file.name}:`, err);
@@ -374,6 +376,11 @@ export default function HeatmapGenerator() {
       setIsLoading(false);
     }
   };
+
+  const getOriginalFiles = useCallback(
+    () => files.map((f) => ({ name: f.name, blob: f.blob })).filter((f) => f.blob),
+    [files]
+  );
 
   const handleClear = () => {
     setFiles([]);
@@ -487,6 +494,20 @@ export default function HeatmapGenerator() {
                       <span className={styles.pointCount}>{file.pointCount.toLocaleString()} pts</span>
                     </div>
                   ))}
+                </div>
+              )}
+
+              {files.length > 0 && (
+                <div className={styles.saveToAccountSection}>
+                  <p className={styles.saveToAccountIntro}>
+                    Want this in your Dawarich account too? We'll import it during signup — no second upload needed.
+                  </p>
+                  <SaveToAccountButton
+                    toolName="heatmap-generator"
+                    sourceHint={null}
+                    getFiles={getOriginalFiles}
+                    disabled={files.length === 0}
+                  />
                 </div>
               )}
 

--- a/src/pages/tools/heatmap-generator.js
+++ b/src/pages/tools/heatmap-generator.js
@@ -590,7 +590,7 @@ export default function HeatmapGenerator() {
               <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" width="20" height="20">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
               </svg>
-              <span>Your data stays in your browser. Nothing is uploaded to any server.</span>
+              <span>Rendering happens in your browser. Nothing is uploaded unless you choose “Save to my Dawarich account.”</span>
             </div>
           </div>
 

--- a/src/pages/tools/heatmap-generator.js
+++ b/src/pages/tools/heatmap-generator.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
-import SaveToAccountButton from '@site/src/components/SaveToAccountButton';
+import SaveToAccountButton, { useHandoffEnabled } from '@site/src/components/SaveToAccountButton';
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 import BrowserOnly from '@docusaurus/BrowserOnly';
@@ -305,6 +305,7 @@ function getColorRamp(scheme) {
 }
 
 export default function HeatmapGenerator() {
+  const handoffEnabled = useHandoffEnabled();
   const [files, setFiles] = useState([]);
   const [points, setPoints] = useState([]);
   const [stats, setStats] = useState(null);
@@ -497,7 +498,7 @@ export default function HeatmapGenerator() {
                 </div>
               )}
 
-              {files.length > 0 && (
+              {handoffEnabled && files.length > 0 && (
                 <div className={styles.saveToAccountSection}>
                   <p className={styles.saveToAccountIntro}>
                     Want this in your Dawarich account too? We'll import it during signup — no second upload needed.

--- a/src/pages/tools/heatmap-generator.module.css
+++ b/src/pages/tools/heatmap-generator.module.css
@@ -394,3 +394,18 @@
   margin-bottom: 0.5rem;
 }
 
+
+/* Save-to-account handoff */
+.saveToAccountSection {
+  margin-top: 1rem;
+  padding: 1.25rem;
+  border: 1px dashed var(--ifm-color-primary);
+  border-radius: 8px;
+  text-align: center;
+}
+
+.saveToAccountIntro {
+  margin: 0 0 1rem;
+  font-size: 0.95rem;
+  color: var(--ifm-color-emphasis-700);
+}

--- a/src/pages/tools/timeline-mileage-calculator.js
+++ b/src/pages/tools/timeline-mileage-calculator.js
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useMemo } from 'react';
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 import FileUploader from '@site/src/components/FileUploader';
+import SaveToAccountButton from '@site/src/components/SaveToAccountButton';
 import StatsCard from '@site/src/components/StatsCard';
 import { parseTimeline } from '@site/src/utils/timelineParser';
 import { generateMileageLog, mileageLogToCSV } from '@site/src/utils/timelineStats';
@@ -88,6 +89,11 @@ export default function TimelineMileageCalculator() {
   const [mileageLog, setMileageLog] = useState(null);
   const [isProcessing, setIsProcessing] = useState(false);
   const [visibleTrips, setVisibleTrips] = useState(20);
+
+  const getOriginalFiles = useCallback(
+    () => uploadedFiles.map((f) => ({ name: f.filename, blob: f.blob })),
+    [uploadedFiles]
+  );
 
   const handleFilesLoaded = useCallback(async (files) => {
     setUploadedFiles(files);
@@ -363,6 +369,20 @@ export default function TimelineMileageCalculator() {
 
             <div className={styles.uploaderWrapper}>
               <FileUploader onFilesLoaded={handleFilesLoaded} onClear={handleClear} />
+
+              {uploadedFiles.length > 0 && (
+                <div className={styles.saveToAccountSection}>
+                  <p className={styles.saveToAccountIntro}>
+                    Want this in your Dawarich account too? We'll import it during signup — no second upload needed.
+                  </p>
+                  <SaveToAccountButton
+                    toolName="timeline-mileage-calculator"
+                    sourceHint={null}
+                    getFiles={getOriginalFiles}
+                    disabled={uploadedFiles.length === 0}
+                  />
+                </div>
+              )}
 
               <div className={styles.privacyNote}>
                 <div>

--- a/src/pages/tools/timeline-mileage-calculator.js
+++ b/src/pages/tools/timeline-mileage-calculator.js
@@ -18,7 +18,7 @@ const imageUrl = "https://dawarich.app/img/meta-image.png";
 const faqItems = [
   {
     question: "Is it safe to upload my Google Timeline data?",
-    answer: "Absolutely. This tool runs 100% in your browser using client-side JavaScript. Your Google Timeline files are never uploaded to any server, never leave your device, and are discarded the moment you close or refresh the page. There is no backend, no database, and no tracking of your location data. The tool is part of the Dawarich open-source ecosystem, so you can inspect the source code yourself to verify."
+    answer: "Absolutely. The calculator runs 100% in your browser using client-side JavaScript — your files stay on your device and are discarded when you close or refresh the page, with no tracking of your location data. The only exception is the optional “Save to my Dawarich account” button, which uploads your file to Dawarich Cloud so it can be imported into your new account. The tool is part of the Dawarich open-source ecosystem, so you can inspect the source code yourself."
   },
   {
     question: "How accurate is the mileage calculation?",
@@ -339,7 +339,7 @@ export default function TimelineMileageCalculator() {
         <div className={styles.contentWrapper}>
           <div className={styles.header}>
             <h1>Google Timeline Mileage Calculator</h1>
-            <p>Calculate driving mileage from your Google Timeline data. Generate downloadable mileage logs with per-trip details, daily and monthly summaries. All processing happens in your browser — your data never leaves your device.</p>
+            <p>Calculate driving mileage from your Google Timeline data. Generate downloadable mileage logs with per-trip details, daily and monthly summaries. All processing happens in your browser — your data stays on your device unless you choose “Save to my Dawarich account.”</p>
           </div>
 
           <div className={styles.topSection}>
@@ -392,7 +392,7 @@ export default function TimelineMileageCalculator() {
                     </svg>
                     Privacy First
                   </strong>
-                  <p>All mileage calculations happen entirely in your browser. Your location data never leaves your device and is not sent to any server.</p>
+                  <p>All mileage calculations happen entirely in your browser — your location data stays on your device unless you choose “Save to my Dawarich account.”</p>
                 </div>
               </div>
             </div>
@@ -642,7 +642,7 @@ export default function TimelineMileageCalculator() {
             <div className={styles.infoCard}>
               <h2>What Is the Timeline Mileage Calculator?</h2>
               <p>The Timeline Mileage Calculator is a free browser-based tool that extracts driving trip data from your Google Timeline export files and calculates the total distance traveled. It identifies driving-related activity segments — including car trips, bus rides, train journeys, and motorcycle travel — and generates a structured mileage log with per-trip details.</p>
-              <p>Unlike server-based tools, everything runs in your browser. Your sensitive location data is never uploaded anywhere. You get instant results with full privacy, and the generated CSV mileage log can be used for expense reports, tax documentation, or personal record-keeping.</p>
+              <p>Unlike server-based tools, all calculations run in your browser, so generating your mileage log never sends your location data anywhere. You get instant results with full privacy, and the generated CSV mileage log can be used for expense reports, tax documentation, or personal record-keeping. (If you use “Save to my Dawarich account,” that one action uploads your file to Dawarich Cloud to set up your import — nothing is sent otherwise.)</p>
             </div>
 
             <div className={styles.infoCard}>

--- a/src/pages/tools/timeline-mileage-calculator.js
+++ b/src/pages/tools/timeline-mileage-calculator.js
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useMemo } from 'react';
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 import FileUploader from '@site/src/components/FileUploader';
-import SaveToAccountButton from '@site/src/components/SaveToAccountButton';
+import SaveToAccountButton, { useHandoffEnabled } from '@site/src/components/SaveToAccountButton';
 import StatsCard from '@site/src/components/StatsCard';
 import { parseTimeline } from '@site/src/utils/timelineParser';
 import { generateMileageLog, mileageLogToCSV } from '@site/src/utils/timelineStats';
@@ -80,6 +80,7 @@ function formatActivityType(type) {
 }
 
 export default function TimelineMileageCalculator() {
+  const handoffEnabled = useHandoffEnabled();
   const [uploadedFiles, setUploadedFiles] = useState([]);
   const [allPoints, setAllPoints] = useState([]);
   const [allPaths, setAllPaths] = useState([]);
@@ -370,7 +371,7 @@ export default function TimelineMileageCalculator() {
             <div className={styles.uploaderWrapper}>
               <FileUploader onFilesLoaded={handleFilesLoaded} onClear={handleClear} />
 
-              {uploadedFiles.length > 0 && (
+              {handoffEnabled && uploadedFiles.length > 0 && (
                 <div className={styles.saveToAccountSection}>
                   <p className={styles.saveToAccountIntro}>
                     Want this in your Dawarich account too? We'll import it during signup — no second upload needed.

--- a/src/pages/tools/timeline-mileage-calculator.module.css
+++ b/src/pages/tools/timeline-mileage-calculator.module.css
@@ -926,3 +926,18 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* Save-to-account handoff */
+.saveToAccountSection {
+  margin-top: 1rem;
+  padding: 1.25rem;
+  border: 1px dashed var(--ifm-color-primary);
+  border-radius: 8px;
+  text-align: center;
+}
+
+.saveToAccountIntro {
+  margin: 0 0 1rem;
+  font-size: 0.95rem;
+  color: var(--ifm-color-emphasis-700);
+}

--- a/src/pages/tools/timeline-visualizer.js
+++ b/src/pages/tools/timeline-visualizer.js
@@ -4,6 +4,7 @@ import RelatedTools from '@site/src/components/RelatedTools';
 import Head from '@docusaurus/Head';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import FileUploader from '@site/src/components/FileUploader';
+import SaveToAccountButton from '@site/src/components/SaveToAccountButton';
 import TimelinePanel from '@site/src/components/TimelinePanel/TimelinePanel';
 import { parseTimeline } from '@site/src/utils/timelineParser';
 import { SAMPLE_DAY } from '@site/src/utils/sampleBerlinData';
@@ -164,6 +165,11 @@ export default function TimelineVisualizer() {
     setYearStats(buildYearStats(idx));
     setIsProcessing(false);
   }, []);
+
+  const getOriginalFiles = useCallback(
+    () => uploadedFiles.map((f) => ({ name: f.filename, blob: f.blob })),
+    [uploadedFiles]
+  );
 
   const handleClear = useCallback(() => {
     setUploadedFiles([]);
@@ -379,6 +385,19 @@ export default function TimelineVisualizer() {
           </div>
           <div className={styles.uploadRow}>
             <FileUploader onFilesLoaded={handleFilesLoaded} onClear={handleClear} />
+            {!isShowingSample && points.length > 0 && (
+              <div className={styles.saveToAccountSection}>
+                <p className={styles.saveToAccountIntro}>
+                  Want this in your Dawarich account too? We'll import it during signup — no second upload needed.
+                </p>
+                <SaveToAccountButton
+                  toolName="timeline-visualizer"
+                  sourceHint={null}
+                  getFiles={getOriginalFiles}
+                  disabled={uploadedFiles.length === 0}
+                />
+              </div>
+            )}
             <div className={styles.uploadMeta}>
               <div className={styles.privacyBadge}>
                 <svg className={styles.privacyIcon} fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/pages/tools/timeline-visualizer.js
+++ b/src/pages/tools/timeline-visualizer.js
@@ -21,7 +21,7 @@ const imageUrl = "https://dawarich.app/img/meta-image.png";
 const faqItems = [
   {
     question: "Is it safe to upload my Google Timeline data here?",
-    answer: "Yes. All data processing happens entirely in your browser using JavaScript. Your location history files are never uploaded to any server — they stay on your device. When you close the tab, the data is gone. The tool is also open source, so you can verify exactly what the code does."
+    answer: "Yes. All visualization happens entirely in your browser using JavaScript — your files stay on your device and are gone when you close the tab. The only exception is the optional “Save to my Dawarich account” button, which uploads your file to Dawarich Cloud so it can be imported into your new account. The tool is open source, so you can verify exactly what the code does."
   },
   {
     question: "What file formats does this visualizer support?",
@@ -403,7 +403,7 @@ export default function TimelineVisualizer() {
                 <svg className={styles.privacyIcon} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
                 </svg>
-                <span>All processing happens in your browser. Your data never leaves your device.</span>
+                <span>All processing happens in your browser. Your data stays on your device unless you choose “Save to my Dawarich account.”</span>
               </div>
               <details className={styles.instructionsCollapsible}>
                 <summary className={styles.instructionsSummary}>
@@ -530,7 +530,7 @@ export default function TimelineVisualizer() {
             <div className={styles.infoCard}>
               <h2>What Is a Google Timeline Visualizer?</h2>
               <p>A Google Timeline visualizer takes the raw JSON files from your Google location history export and turns them into an interactive map you can explore. Instead of scrolling through thousands of lines of coordinates and timestamps, you see your actual journeys plotted on a map — every trip, commute, and walk you've taken while Google was tracking your location.</p>
-              <p>This tool processes everything in your browser, so your sensitive location data never leaves your device. It's the privacy-first way to explore years of location history.</p>
+              <p>This tool visualizes everything in your browser, so exploring your history never sends your location data anywhere. It's the privacy-first way to explore years of location history. (If you use “Save to my Dawarich account,” that one action uploads your file to Dawarich Cloud to set up your import — nothing is sent otherwise.)</p>
             </div>
 
             <div className={styles.infoCard}>

--- a/src/pages/tools/timeline-visualizer.js
+++ b/src/pages/tools/timeline-visualizer.js
@@ -4,7 +4,7 @@ import RelatedTools from '@site/src/components/RelatedTools';
 import Head from '@docusaurus/Head';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import FileUploader from '@site/src/components/FileUploader';
-import SaveToAccountButton from '@site/src/components/SaveToAccountButton';
+import SaveToAccountButton, { useHandoffEnabled } from '@site/src/components/SaveToAccountButton';
 import TimelinePanel from '@site/src/components/TimelinePanel/TimelinePanel';
 import { parseTimeline } from '@site/src/utils/timelineParser';
 import { SAMPLE_DAY } from '@site/src/utils/sampleBerlinData';
@@ -68,6 +68,7 @@ function nextMonthKey(monthKey, direction) {
 }
 
 export default function TimelineVisualizer() {
+  const handoffEnabled = useHandoffEnabled();
   const [uploadedFiles, setUploadedFiles] = useState([]);
   const [points, setPoints] = useState([]);
   const [paths, setPaths] = useState([]);
@@ -385,7 +386,7 @@ export default function TimelineVisualizer() {
           </div>
           <div className={styles.uploadRow}>
             <FileUploader onFilesLoaded={handleFilesLoaded} onClear={handleClear} />
-            {!isShowingSample && points.length > 0 && (
+            {handoffEnabled && !isShowingSample && points.length > 0 && (
               <div className={styles.saveToAccountSection}>
                 <p className={styles.saveToAccountIntro}>
                   Want this in your Dawarich account too? We'll import it during signup — no second upload needed.

--- a/src/pages/tools/timeline-visualizer.module.css
+++ b/src/pages/tools/timeline-visualizer.module.css
@@ -684,3 +684,18 @@
   background: var(--ifm-color-emphasis-100);
   border-radius: 8px;
 }
+
+/* Save-to-account handoff */
+.saveToAccountSection {
+  margin-top: 1rem;
+  padding: 1.25rem;
+  border: 1px dashed var(--ifm-color-primary);
+  border-radius: 8px;
+  text-align: center;
+}
+
+.saveToAccountIntro {
+  margin: 0 0 1rem;
+  font-size: 0.95rem;
+  color: var(--ifm-color-emphasis-700);
+}

--- a/src/utils/bundleFiles.js
+++ b/src/utils/bundleFiles.js
@@ -1,0 +1,15 @@
+/**
+ * Bundle one or more files into a single .zip blob using DEFLATE compression.
+ * JSZip is lazy-imported so the dependency only loads when this is called.
+ */
+export async function bundleFiles(files) {
+  const { default: JSZip } = await import('jszip');
+  const zip = new JSZip();
+  files.forEach((f) => zip.file(f.name, f.blob));
+  const blob = await zip.generateAsync({
+    type: 'blob',
+    compression: 'DEFLATE',
+    compressionOptions: { level: 6 },
+  });
+  return { blob, filename: 'dawarich-import.zip' };
+}

--- a/src/utils/bundleFiles.js
+++ b/src/utils/bundleFiles.js
@@ -7,12 +7,14 @@
 export async function bundleFiles(files) {
   const { default: JSZip } = await import('jszip');
   const zip = new JSZip();
-  const seen = new Map();
+  const used = new Set();
 
   files.forEach((f) => {
-    const count = seen.get(f.name) || 0;
-    seen.set(f.name, count + 1);
-    const name = count === 0 ? f.name : dedupedName(f.name, count);
+    let name = f.name;
+    for (let i = 1; used.has(name); i++) {
+      name = dedupedName(f.name, i);
+    }
+    used.add(name);
     zip.file(name, f.blob);
   });
 

--- a/src/utils/bundleFiles.js
+++ b/src/utils/bundleFiles.js
@@ -1,15 +1,31 @@
 /**
  * Bundle one or more files into a single .zip blob using DEFLATE compression.
  * JSZip is lazy-imported so the dependency only loads when this is called.
+ * Duplicate filenames are uniquified (zip.file overwrites same-named entries,
+ * which would silently drop files from multi-device uploads).
  */
 export async function bundleFiles(files) {
   const { default: JSZip } = await import('jszip');
   const zip = new JSZip();
-  files.forEach((f) => zip.file(f.name, f.blob));
+  const seen = new Map();
+
+  files.forEach((f) => {
+    const count = seen.get(f.name) || 0;
+    seen.set(f.name, count + 1);
+    const name = count === 0 ? f.name : dedupedName(f.name, count);
+    zip.file(name, f.blob);
+  });
+
   const blob = await zip.generateAsync({
     type: 'blob',
     compression: 'DEFLATE',
     compressionOptions: { level: 6 },
   });
   return { blob, filename: 'dawarich-import.zip' };
+}
+
+function dedupedName(name, count) {
+  const dot = name.lastIndexOf('.');
+  if (dot <= 0) return `${name}_${count}`;
+  return `${name.slice(0, dot)}_${count}${name.slice(dot)}`;
 }

--- a/src/utils/detectGoogleSource.js
+++ b/src/utils/detectGoogleSource.js
@@ -1,0 +1,22 @@
+/**
+ * Map the converter's internal format names to Dawarich Import.source enum values.
+ * Returns null when no specific source can be inferred (server-side detector will run).
+ */
+const FORMAT_TO_SOURCE = {
+  records: 'google_records',
+  semantic: 'google_semantic_history',
+  semanticSegments: 'google_phone_takeout',
+  locationHistory: 'google_phone_takeout',
+};
+
+export function detectGoogleSource(parsedResults) {
+  if (!parsedResults || parsedResults.length === 0) return null;
+
+  const formats = new Set(parsedResults.map((r) => r.format).filter(Boolean));
+  if (formats.size === 0) return null;
+
+  for (const format of formats) {
+    if (FORMAT_TO_SOURCE[format]) return FORMAT_TO_SOURCE[format];
+  }
+  return null;
+}


### PR DESCRIPTION
## What

Adds a **Save to my Dawarich account** button to all 5 free tools (Google Timeline converter, timeline visualizer, heatmap generator, GPX merger, mileage calculator).

Click → files are bundled into a zip in the browser (JSZip, lazy-loaded on first click) → POSTed to `my.dawarich.app/api/v1/imports/pending` → browser redirects into signup with the returned single-use claim ticket → the file is auto-imported into the new account. No second upload.

- Inline error states: 413 (too large), 429 (rate-limited), network failure
- `utm_campaign=<toolName>` appended to the claim URL for attribution
- Converter/visualizer/mileage hand off the original uploads; heatmap now retains raw file blobs in its state; GPX merger hands off the **merged output** file
- Single-file bundles are named `<original>.zip` so the server-side source detector sees zip bytes with a zip extension

## Verification

- `npm run build` succeeds
- Backend contract verified via the Rails request specs and an isolated-stack E2E run (companion PR: Freika/dawarich#2808)

## Rollout

The save-to-account UI is **dark-launched**: it only renders when a tool page is opened with `?handoff=1`. Deploy order is therefore decoupled from Freika/dawarich#2808 — ship the site anytime, test against production via the param, and remove the gate (`useHandoffEnabled`) for the public rollout once the backend endpoint is live.
