### PR TITLE
Legal pages for poster print sales

### DIFF
--- a/src/pages/privacy-policy.md
+++ b/src/pages/privacy-policy.md
@@ -23,6 +23,9 @@ This policy applies to the Dawarich SaaS at `dawarich.app`, the hosted tier, and
 | Billing data (name, email, address, tax ID, payment metadata) | Subscriptions, invoicing, tax | (1)(b) contract; (1)(c) legal obligation |
 | Error logs, crash reports, performance metrics | Keep the service stable and secure | (1)(f) legitimate interest |
 | Support correspondence | Respond to your requests | (1)(b) / (1)(f) |
+| Poster print orders (name, shipping address, email, phone, the poster file) | Produce and ship posters you order, invoicing | (1)(b) contract; (1)(c) legal obligation |
+
+The poster file you order is a map rendering of the location data you selected in the Poster Studio. It is shared with our payment and print partners (Section 3) solely to process and produce your order.
 
 No automated decision-making with legal effect (Art. 22). Providing this data is voluntary but necessary to use the service.
 
@@ -44,13 +47,16 @@ All listed processors are bound by DPAs under Art. 28 GDPR. We do not sell data 
 | Sendinblue SAS (Brevo) — web tracker | Marketing-site email-campaign pixel — consent-based | France (EU) |
 | Apple Inc. | iOS App Store distribution | United States |
 | Google LLC | Google Play distribution | United States |
+| Stripe Payments Europe, Ltd. | Payment processing for poster print orders | Ireland (EU); parent Stripe, Inc. (US) |
+| Gelato ASA | Poster printing and shipping (receives shipping details and the poster file) | Norway (EEA); production within the EU |
 
-**International transfers:** UK (Paddle) is covered by the EU adequacy decision. US transfers rely on the EU-US Data Privacy Framework where the provider is certified, and on Standard Contractual Clauses (Art. 46 GDPR) otherwise.
+**International transfers:** UK (Paddle) is covered by the EU adequacy decision. Norway (Gelato) is in the EEA, where the GDPR applies directly. US transfers rely on the EU-US Data Privacy Framework where the provider is certified, and on Standard Contractual Clauses (Art. 46 GDPR) otherwise.
 
 ## 4. Retention
 
 - **Account and location data:** while your account is active; up to 12 months after cancellation unless you request earlier deletion.
-- **Billing data:** up to 10 years (§ 147 AO, § 257 HGB).
+- **Poster print files:** deleted within 48 hours if the order is not paid; kept up to 90 days after purchase for reprints and support, then deleted.
+- **Billing data (including poster order records):** up to 10 years (§ 147 AO, § 257 HGB).
 - **Error logs:** up to 30 days.
 - **Support correspondence:** up to 3 years after last contact.
 
@@ -95,6 +101,7 @@ Effective **2026-04-21**. Contact for all privacy matters: **hi@dawarich.app**.
 
 | When          | What          |
 | ------------- | ------------- |
+| 2026-07-18    | Added poster print orders: order data, Stripe and Gelato processors, print-file retention (48h unpaid / 90 days paid) |
 | 2026-04-21    | Added processor list, legal bases, rights, supervisory authority, transfers, cookie table; age to 16; reflected STORE_GEODATA=false; 30-day notice for material changes |
 | 2025-09-12    | Added TL;DR section |
 | 2025-03-12    | Updated data retention section for SaaS users |

--- a/src/pages/refund-policy.md
+++ b/src/pages/refund-policy.md
@@ -42,11 +42,25 @@ As a consumer resident in the EU, you have a statutory right to withdraw from th
 >
 > (*) Delete as appropriate.
 
-## 3. No Refunds Outside the Withdrawal Period
+## 3. Poster Prints (Physical Goods)
+
+Printed posters ordered in the Poster Studio are produced individually from your own location data.
+
+**No right of withdrawal.** Because each poster is made to your specification and clearly personalized, the statutory 14-day right of withdrawal does not apply to poster print orders (§ 312g Abs. 2 Nr. 1 BGB). You are informed of this before completing the order, and by placing the order you acknowledge it. This means a correctly produced poster cannot be returned or refunded simply because you changed your mind.
+
+**Defective, damaged, or lost orders.** Your statutory warranty rights (§§ 434 ff. BGB) are unaffected. If your poster
+
+- arrives damaged or with a print defect,
+- materially differs from what you ordered, or
+- does not arrive at all,
+
+contact **hi@dawarich.app** — ideally with your order reference and, for damage or defects, a photo. We will reprint the poster free of charge or refund the full purchase price, at your choice.
+
+## 4. No Refunds Outside the Withdrawal Period
 
 Outside the statutory 14-day window, we do not refund partial use, unused periods, or remaining time on a subscription. Once a subscription renews it is non-refundable for that cycle, except where applicable consumer protection law requires otherwise.
 
-## 4. Contact
+## 5. Contact
 
 For billing or withdrawal requests: **hi@dawarich.app**.
 
@@ -54,6 +68,7 @@ For billing or withdrawal requests: **hi@dawarich.app**.
 
 | When          | What          |
 | ------------- | ------------- |
+| 2026-07-18    | Added poster prints: § 312g Abs. 2 Nr. 1 BGB withdrawal exclusion for personalized goods, warranty and replacement terms |
 | 2026-04-26    | Documented dual trial flows (with and without payment details upfront) |
 | 2026-04-21    | Added statutory 14-day right of withdrawal, aligned plans with current pricing |
 | 2026-03-10    | Added monthly plan |

--- a/src/pages/terms-and-conditions.md
+++ b/src/pages/terms-and-conditions.md
@@ -24,27 +24,37 @@ All paid plans include a 7-day free trial. Depending on the sign-up flow shown t
 
 In both cases you can cancel at any time from Subscription Settings; cancellation during the trial prevents any charge. Once a paid subscription is active, it renews automatically at the end of each billing cycle unless canceled; cancellation takes effect at the end of the current cycle and requires no advance notice. Your statutory right of withdrawal and refund conditions are set out in the [Refund Policy](/refund-policy).
 
-## 4. User Responsibilities
+## 4. Poster Prints (Physical Goods)
+
+In addition to subscriptions, you can order printed posters generated from your own location data in the Poster Studio.
+
+- **Products and prices.** Personalized map posters on 200 gsm premium matte paper: 30 × 40 cm — €34.99, 50 × 70 cm — €54.99, 70 × 100 cm — €74.99. Prices include VAT and shipping.
+- **Ordering and payment.** Orders are one-off purchases paid via Stripe Checkout. The contract is concluded when your payment is completed; you receive an order confirmation by email and can follow the order on its status page.
+- **Fulfillment and shipping.** Posters are printed and shipped by our production partner Gelato, normally from a print facility in or near your country. We currently ship to EU member states only. Production and delivery typically take several business days; delivery times vary by country.
+- **Personalized goods — no right of withdrawal.** Each poster is produced to your specification from your own data. The statutory 14-day right of withdrawal therefore does not apply (§ 312g Abs. 2 Nr. 1 BGB); you are informed of this before you place the order. See the [Refund Policy](/refund-policy) for details.
+- **Defects.** Your statutory warranty rights are unaffected. If a poster arrives damaged, misprinted, or not at all, contact **hi@dawarich.app** and we will reprint or refund it — see the [Refund Policy](/refund-policy).
+
+## 5. User Responsibilities
 
 Provide accurate information at registration and do not misuse the service, attempt unauthorized access, or use Dawarich for illegal activities.
 
-## 5. Abuse
+## 6. Abuse
 
 We may cancel any account we deem abusive, at our discretion. Where circumstances allow, we will provide a reasonable window to export your data.
 
-## 6. Service Availability
+## 7. Service Availability
 
 Dawarich is provided "as is". We cannot guarantee uninterrupted availability, but we will give advance notice of significant changes and ensure you can export your data within the retention period if a feature or service is discontinued.
 
-## 7. Liability
+## 8. Liability
 
 To the extent permitted by law, we are not liable for indirect, incidental, or consequential damages, or for data loss caused by third-party failures or force majeure. You are responsible for keeping your own backups. Nothing limits our liability for intent, gross negligence, injury to life, body or health, or liability under the German Product Liability Act.
 
-## 8. Governing Law and Dispute Resolution
+## 9. Governing Law and Dispute Resolution
 
 These terms are governed by the law of the Federal Republic of Germany, excluding the UN CISG. Mandatory consumer protection law of your country of residence remains unaffected. The EU online dispute resolution platform is at [ec.europa.eu/consumers/odr](https://ec.europa.eu/consumers/odr); we are not obliged and not willing to participate in consumer arbitration proceedings.
 
-## 9. Changes
+## 10. Changes
 
 We may update these terms and will notify users of material changes.
 
@@ -52,6 +62,7 @@ We may update these terms and will notify users of material changes.
 
 | When          | What          |
 | ------------- | ------------- |
+| 2026-07-18    | Added Poster Prints section (physical goods: products, prices, Stripe payment, Gelato fulfillment, § 312g exclusion, warranty) |
 | 2026-04-26    | Documented dual trial flows (with and without payment details upfront) |
 | 2026-04-21    | Aligned plans with current pricing, age to 16, removed one-month cancellation notice, added governing law and ODR |
 | 2025-04-13    | Added abuse section and general terms |


### PR DESCRIPTION
Extends the 2026-04 legal overhaul for the physical-goods poster pipeline going live on prints.dawarich.app.

- **Terms and Conditions** — new *Poster Prints (Physical Goods)* section: the three products with prices (VAT and shipping included), one-off payment via Stripe Checkout, fulfillment and EU-only shipping by Gelato, the § 312g Abs. 2 Nr. 1 BGB withdrawal exclusion for personalized goods, and statutory warranty reference. Subsequent sections renumbered.
- **Refund Policy** — new section covering the withdrawal exclusion for custom prints (with the pre-order acknowledgment the checkout collects) and the remedy path: free reprint or full refund for damaged, misprinted, or lost orders.
- **Privacy Policy** — print-order data (name, shipping address, email, phone, poster file) with Art. 6(1)(b)/(c) bases, Stripe Payments Europe (IE) and Gelato ASA (NO/EEA) added as processors, EEA transfer note, and retention for print files (48 h unpaid purge, 90 days after purchase).

Impressum unchanged — ZeitFlow UG covers poster sales. Build passes (`npm run build`); only pre-existing warnings.