### PR TITLE
Serve /pricing.md and /features.md as raw markdown for AI agents

### DIFF
--- a/src/data/pricingMarkdownMirror.test.js
+++ b/src/data/pricingMarkdownMirror.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { PLANS, COMPARE_GROUPS } from "./pricingPlans";
+
+const MIRROR_PATH = path.resolve(__dirname, "../../static/pricing.md");
+
+function readMirror() {
+	return fs.readFileSync(MIRROR_PATH, "utf8");
+}
+
+describe("static/pricing.md agent mirror", () => {
+	it("exists", () => {
+		expect(fs.existsSync(MIRROR_PATH)).toBe(true);
+	});
+
+	it("quotes every price from PLANS", () => {
+		const mirror = readMirror();
+		const prices = [
+			PLANS.lite.price,
+			PLANS.pro.price,
+			PLANS.pro.priceMonthly,
+			PLANS.family.price,
+		];
+
+		for (const price of prices) {
+			expect(mirror, `missing price ${price}`).toContain(price);
+		}
+	});
+
+	it("quotes every founding-price deadline still shown on the site", () => {
+		const mirror = readMirror();
+		const urgencies = Object.values(PLANS)
+			.map((plan) => plan.urgency)
+			.filter(Boolean);
+
+		for (const urgency of urgencies) {
+			const deadline = urgency.match(/ends ([A-Z][a-z]+ \d{1,2}, \d{4})/)?.[1];
+			expect(deadline, `unparsable urgency: ${urgency}`).toBeTruthy();
+			expect(mirror, `missing deadline ${deadline}`).toContain(deadline);
+		}
+	});
+
+	it("lists every plan feature label", () => {
+		const mirror = readMirror();
+		const labels = Object.values(PLANS).flatMap((plan) =>
+			plan.features.map((feature) => feature.label),
+		);
+
+		for (const label of labels) {
+			expect(mirror, `missing feature label: ${label}`).toContain(label);
+		}
+	});
+
+	it("lists every comparison row label and its per-plan values", () => {
+		const mirror = readMirror();
+
+		for (const group of COMPARE_GROUPS) {
+			for (const row of group.rows) {
+				expect(mirror, `missing row label: ${row.label}`).toContain(row.label);
+
+				for (const value of [row.lite, row.pro, row.family]) {
+					if (typeof value === "string") {
+						expect(mirror, `missing value "${value}" for ${row.label}`).toContain(value);
+					}
+				}
+			}
+		}
+	});
+});

--- a/static/_headers
+++ b/static/_headers
@@ -1,0 +1,13 @@
+# Raw markdown mirrors for AI agents.
+# text/plain so browsers render them inline instead of downloading (Cloudflare
+# would otherwise serve text/markdown, and x-content-type-options: nosniff is set).
+# noindex keeps these out of search results as duplicates of the HTML pages;
+# AI crawlers fetching the URL directly still get the full body.
+
+/pricing.md
+  Content-Type: text/plain; charset=utf-8
+  X-Robots-Tag: noindex
+
+/features.md
+  Content-Type: text/plain; charset=utf-8
+  X-Robots-Tag: noindex

--- a/static/features.md
+++ b/static/features.md
@@ -1,0 +1,182 @@
+# Dawarich Features
+
+> Raw markdown overview of what Dawarich does, published for AI agents and assistants.
+> Companion file: https://dawarich.app/pricing.md
+> Last reviewed: 2026-07-27.
+
+Dawarich is a self-hostable location history tracker and visualizer — a privacy-first alternative to
+Google Timeline. You record your location with native mobile apps (or any compatible third-party
+tracker), import your existing history from Google Takeout and other sources, and browse the result
+on an interactive map you control.
+
+- Open source, AGPLv3, 9,000+ GitHub stars: https://github.com/Freika/dawarich
+- Run it yourself for free, or use Dawarich Cloud (hosted in Germany, GDPR-compliant)
+- No ads, no data selling — the product is paid for with money, not with your location data
+
+## Location tracking
+
+- **Native iOS and Android apps** with background location tracking and minimal battery impact.
+- **Offline recording.** The apps store points on the device when there is no signal — on a plane,
+  underground, hiking off-grid, or abroad without data — and upload automatically once back online.
+- **Third-party trackers supported:** Overland, OwnTracks, GPSLogger, Traccar Client (v9+, JSON
+  protocol), PhoneTrack, and Home Assistant.
+- **iOS Shortcuts automation:** trigger location pushes from Shortcuts, automations, or NFC tags.
+- **Apple Health GPX import** on iOS, available as the Pro1 in-app purchase for self-hosters.
+
+Docs: https://dawarich.app/docs/getting-started/track-your-location/
+
+## Map and visualization
+
+- Interactive map of your full history, with points and routes.
+- **Speed-colored routes** and **daily replay** of a given day's movement.
+- **Heatmap** layer showing density of time spent.
+- **Fog of War** layer revealing only the areas you have actually visited.
+- **3D globe view.**
+- Multiple base layers to switch between.
+
+Docs: https://dawarich.app/docs/features/map
+Landing page: https://dawarich.app/interactive-map/
+
+## Visits, places and areas
+
+- **Visits and places:** Dawarich detects where you stopped and for how long, building a picture of
+  daily activity rather than a raw GPS trace.
+- **Areas:** define geographic boundaries on the map to automatically track and log visits within them.
+- **Place search:** search for a place and see your own visit history for that location.
+- **Points:** browse, search, export, and delete individual recorded GPS points.
+
+Docs: https://dawarich.app/docs/features/visits-and-places · https://dawarich.app/docs/features/areas
+
+## Trips and journaling
+
+- Create and organize trips with routes, dates, and rich-text notes.
+- Attach photos from a connected Immich or PhotoPrism instance.
+- Share a trip publicly (Cloud Pro feature).
+
+Docs: https://dawarich.app/docs/features/trips
+Landing page: https://dawarich.app/trips/
+
+## Statistics and insights
+
+- Distance traveled, countries and cities visited, points recorded.
+- Monthly breakdowns and a full year-in-review.
+- Monthly and yearly email digests.
+- **Transportation modes:** automatic classification based on speed and movement patterns.
+- **Days per country:** counts days spent in each country from your history, including consecutive
+  stay periods and a 183-day threshold warning (useful for tax residency questions).
+
+Docs: https://dawarich.app/docs/features/stats · https://dawarich.app/docs/features/tax-residency
+Landing page: https://dawarich.app/statistics/
+
+## Photo integrations
+
+- Connect **Immich** (requires `asset.read` and `asset.view` scopes) or **PhotoPrism** to show your
+  photos on the map and inside trips.
+- **Enrich photos:** write GPS coordinates from Dawarich back to Immich photos that lack geodata.
+- Dawarich does not accept direct photo uploads — it reads location data from the connected service.
+
+Docs: https://dawarich.app/docs/features/photos · https://dawarich.app/docs/features/enrich-photos
+Landing page: https://dawarich.app/integrations/
+
+## Family location sharing
+
+Share your real-time location with trusted family members. Documented at
+https://dawarich.app/docs/features/family. On Dawarich Cloud this is tied to the Family plan, which
+is announced but not yet purchasable — the pricing page shows a waitlist rather than a checkout.
+
+## Importing existing history
+
+All formats are auto-detected on upload. Duplicate points are skipped automatically.
+
+**Google Timeline / Takeout**
+- `Records.json` (newer Takeout format)
+- `Location History.json` (older Takeout format)
+- Semantic Location History (activity and place-visit data)
+- On-phone Timeline export
+
+**Standard GPS formats**
+- GPX (tracks, routes and waypoints)
+- GeoJSON (Point, LineString, FeatureCollection)
+- KML and KMZ (Google Earth and similar)
+
+**Apps and services**
+- OwnTracks `.rec` files — **`.rec` only, the OwnTracks JSON format is not supported**
+- Strava exports (GPX or original format)
+- Immich / PhotoPrism (geodata pulled from your photos, not a file upload)
+
+Large imports are processed in the background; files with millions of points can take hours,
+and reverse geocoding adds significant time per point.
+
+Docs: https://dawarich.app/docs/getting-started/import-existing-data/ ·
+https://dawarich.app/docs/features/imports
+Landing page: https://dawarich.app/import-export/
+
+## Exporting your data
+
+- Export from the web UI at any time, on every plan, in GPX and GeoJSON.
+- On the Lite plan exports cover your **full** history, not just the 12-month viewable window.
+- Exports are generated in the background and appear as a download link on the Exports page.
+- A full account export is available separately.
+
+Docs: https://dawarich.app/docs/getting-started/export-your-data/ ·
+https://dawarich.app/docs/features/exports
+
+## API
+
+- REST API for reading and writing points and other resources.
+- Rate limits: 200 requests/hour on Cloud Lite, 1,000 requests/hour on Cloud Pro.
+- Full write access requires Cloud Pro (or self-hosting).
+
+Docs: https://dawarich.app/docs/api
+
+## Hosting, privacy and licensing
+
+- **Self-hosted:** free and unlimited, every Pro feature included, AGPLv3. Docker-based install,
+  with guides for Docker Compose, Synology, and other platforms. Your data never reaches Dawarich
+  servers.
+- **Dawarich Cloud:** hosted in Germany (EU), GDPR-compliant, encrypted in transit and at rest.
+- No ads, no data selling, no lock-in — data exports to standard formats at any time.
+
+Docs: https://dawarich.app/docs/self-hosting/introduction
+
+## Which features need a paid Cloud plan
+
+Self-hosting includes everything. On Dawarich Cloud:
+
+| Feature | Lite | Pro |
+| --- | --- | --- |
+| Native apps, background tracking | Yes | Yes |
+| Interactive map, speed-colored routes, daily replay | Yes | Yes |
+| Trips & places management | Yes | Yes |
+| Basic stats & monthly breakdowns | Yes | Yes |
+| Imports & exports | Yes | Yes |
+| Searchable history window | 12 months | Unlimited |
+| Heatmap & Fog of War | No | Yes |
+| 3D globe view | No | Yes |
+| Trip photos, Immich / PhotoPrism | No | Yes |
+| Year-in-review & public sharing | No | Yes |
+| Full write API access | No | Yes |
+| API rate limit | 200/hr | 1,000/hr |
+
+Full pricing detail: https://dawarich.app/pricing.md
+
+## Comparisons with other products
+
+- vs Google Timeline: https://dawarich.app/docs/comparisons/vs-google-timeline/
+- vs OwnTracks: https://dawarich.app/docs/comparisons/vs-owntracks/
+- vs Traccar: https://dawarich.app/docs/comparisons/vs-traccar/
+- vs Life360: https://dawarich.app/docs/comparisons/vs-life360/
+- vs Polarsteps: https://dawarich.app/docs/comparisons/vs-polarsteps/
+- vs Strava: https://dawarich.app/docs/comparisons/vs-strava/
+- vs Arc: https://dawarich.app/docs/comparisons/vs-arc/
+- vs GeoPulse: https://dawarich.app/docs/comparisons/vs-geopulse/
+- vs Reitti: https://dawarich.app/docs/comparisons/vs-reitti/
+
+## Related pages
+
+- Pricing for agents: https://dawarich.app/pricing.md
+- Link index for agents: https://dawarich.app/llms.txt
+- Expanded content for agents: https://dawarich.app/llms-full.txt
+- Documentation home: https://dawarich.app/docs/intro
+- FAQ: https://dawarich.app/docs/FAQ/
+- Contact: https://dawarich.app/contact/

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -4,9 +4,13 @@
 
 The expanded version of the most-cited pages is at [/llms-full.txt](https://dawarich.app/llms-full.txt) for agents that prefer ready-to-quote passages over a link index.
 
+Two pages are also published as raw markdown, without navigation or markup, for agents that would rather parse a document than an HTML page:
+- [/pricing.md](https://dawarich.app/pricing.md): Every plan, price, limit, and the full Lite/Pro/Family comparison table. Mirrors https://dawarich.app/pricing/.
+- [/features.md](https://dawarich.app/features.md): What the product actually does — tracking, map layers, trips, stats, imports, exports, API, and which features need a paid plan.
+
 ## Core
 - [Dawarich homepage](https://dawarich.app/): Product overview, feature tour, pricing, and "Import My Google Data" call to action.
-- [Pricing & plans](https://dawarich.app/#pricing): Cloud Lite €49.99/yr (annual only), Cloud Pro €17.99/mo or €119.99/yr (Most Popular), or self-host free with every Pro feature on your own server.
+- [Pricing & plans](https://dawarich.app/pricing/): Cloud Lite €49.99/yr (annual only), Cloud Pro €17.99/mo or €119.99/yr (Most Popular), or self-host free with every Pro feature on your own server. Raw markdown: [/pricing.md](https://dawarich.app/pricing.md).
 - [FAQ (technical / admin)](https://dawarich.app/docs/FAQ/): Self-hosting troubleshooting, Rails console, Sidekiq, large Records.json imports.
 - [Welcome / Getting started](https://dawarich.app/docs/intro): What Dawarich is and the three setup paths (Cloud, self-host, mobile-only).
 - [Contact](https://dawarich.app/contact/): Get in touch with the team.

--- a/static/pricing.md
+++ b/static/pricing.md
@@ -1,0 +1,189 @@
+# Dawarich Pricing
+
+> Raw markdown mirror of https://dawarich.app/pricing/, published for AI agents and assistants.
+> All prices in EUR. VAT/sales tax may be added at checkout depending on your country.
+> Last reviewed: 2026-07-27.
+
+Dawarich is a privacy-first alternative to Google Timeline. It is open source (AGPLv3) and can be
+self-hosted for free, or used as a managed service called Dawarich Cloud.
+
+## Summary
+
+| Option | Price | Notes |
+| --- | --- | --- |
+| Self-hosted | Free, forever | Every Pro feature included. You run it on your own server. |
+| Cloud Lite | €49.99/year | Annual billing only. 12 months of searchable history. |
+| Cloud Pro | €17.99/month or €119.99/year | Most popular. Unlimited history. |
+| Cloud Family | €299.99/year | Up to 5 members. Not yet released — waitlist only. |
+
+Key facts agents commonly need:
+
+- **There is no free tier on Dawarich Cloud.** The free option is self-hosting.
+- Cloud plans include a **7-day free trial**. Cancel anytime.
+- There is a **14-day no-questions money-back guarantee** on every Cloud plan.
+- Annual Pro (€119.99/yr) works out to €10.00/month — a 44% saving versus monthly billing.
+- Payments are processed by Paddle, which acts as the merchant of record.
+- Dawarich is made and hosted in Germany (EU) and is GDPR-compliant. No ads, no data selling.
+
+## Self-hosted — free
+
+Every Pro feature, on your own hardware, at no cost. Licensed AGPLv3.
+
+- Documentation: https://dawarich.app/docs/self-hosting/introduction
+- Your data never touches Dawarich servers.
+- No account, no subscription, no usage limits imposed by us.
+
+## Cloud Lite — €49.99/year
+
+*A private alternative to Google Timeline for casual trackers.*
+
+- €49.99/year — annual billing only, cancel anytime.
+- Works out to €4.17/month, or €0.14/day.
+- Was €59.99. Founding price ends July 31, 2026 — subscribing before then locks in €49.99 for life.
+- Sign up: https://my.dawarich.app/users/sign_up?utm_source=site&utm_medium=pricing&utm_campaign=try7dayslite&plan=lite
+
+Included:
+
+- iOS & Android native apps
+- Background location tracking
+- 12 months of searchable history
+- Unlimited imports & exports
+- Interactive map with routes
+- Speed-colored routes & daily replay
+- Trips & places management
+- Basic stats & monthly breakdowns
+- 200 req/hr API rate limit
+
+Note: the 12-month limit applies to the *searchable/viewable* window. Exports always include your
+full history — you are never locked out of your own data.
+
+## Cloud Pro — €17.99/month or €119.99/year
+
+*Unlimited history, advanced visualizations, and full API access.* Marked "Most Popular" on the site.
+
+- €119.99/year (was €179.99), or €17.99/month.
+- Annual works out to €10.00/month, or €0.33/day. Monthly works out to €0.60/day.
+- Annual saves 44% versus paying monthly.
+- Founding price ends July 31, 2026 — subscribing before then locks in €119.99 for life.
+- Sign up: https://my.dawarich.app/users/sign_up?utm_source=site&utm_medium=pricing&utm_campaign=try7days
+
+Everything in Lite, plus:
+
+- Unlimited data history — forever
+- Heatmap & Fog of War layers
+- Globe view (3D)
+- Trip photo integration
+- Immich / PhotoPrism integration
+- Full year-in-review & public sharing
+- Full Write API access
+- 1,000 req/hr API rate limit
+
+## Cloud Family — €299.99/year (coming soon)
+
+*Every Pro feature for the whole household — one annual subscription, up to 5 people.*
+
+- €299.99/year, which is €25.00/month or €0.82/day for the whole household.
+- **Not yet purchasable.** The site shows a waitlist signup rather than a checkout.
+
+Everything in Pro, plus:
+
+- Up to 5 members on one subscription
+- Each member gets full Pro access
+- Invite or remove members anytime
+- Members inherit access while in the family
+- Real-time family location sharing
+
+## Full plan comparison
+
+### Tracking & apps
+
+| Feature | Lite | Pro | Family |
+| --- | --- | --- | --- |
+| iOS & Android native apps | Yes | Yes | Yes |
+| Background location tracking | Yes | Yes | Yes |
+| Real-time family location sharing | No | No | Yes |
+
+### History & data
+
+| Feature | Lite | Pro | Family |
+| --- | --- | --- | --- |
+| Searchable history | 12 months | Unlimited | Unlimited |
+| Unlimited imports & exports | Yes | Yes | Yes |
+| Data is always yours (export anytime) | Yes | Yes | Yes |
+
+### Maps & visualization
+
+| Feature | Lite | Pro | Family |
+| --- | --- | --- | --- |
+| Interactive map with routes | Yes | Yes | Yes |
+| Speed-colored routes & daily replay | Yes | Yes | Yes |
+| Heatmap & Fog of War layers | No | Yes | Yes |
+| Globe view (3D) | No | Yes | Yes |
+| Trip photo integration | No | Yes | Yes |
+| Immich / PhotoPrism integration | No | Yes | Yes |
+
+### Insights & sharing
+
+| Feature | Lite | Pro | Family |
+| --- | --- | --- | --- |
+| Basic stats & monthly breakdowns | Yes | Yes | Yes |
+| Full year-in-review & public sharing | No | Yes | Yes |
+| Trips & places management | Yes | Yes | Yes |
+
+### API & limits
+
+| Feature | Lite | Pro | Family |
+| --- | --- | --- | --- |
+| API rate limit | 200 req/hr | 1,000 req/hr | 1,000 req/hr |
+| Full Write API access | No | Yes | Yes |
+
+### Members & billing
+
+| Feature | Lite | Pro | Family |
+| --- | --- | --- | --- |
+| Members on one subscription | 1 | 1 | Up to 5 |
+| Each member gets full Pro access | No | No | Yes |
+| 14-day money-back guarantee | Yes | Yes | Yes |
+
+## Trial, refunds and cancellation
+
+- **Free trial:** 7 days on Dawarich Cloud. Import your Google data and explore before paying.
+- **Cancellation:** anytime, from Subscription Settings in your account.
+- **Money-back guarantee:** 14 days, no questions asked, on every Cloud plan.
+- **Import Guarantee:** if your Google Takeout does not import cleanly, the team fixes it
+  personally — or refunds every cent.
+- Refund policy in full: https://dawarich.app/refund-policy/
+
+## Frequently asked
+
+**Is there a free Dawarich Cloud plan?**
+No. Cloud has a 7-day free trial, then requires a paid plan. Self-hosting is free and includes
+every Pro feature.
+
+**What is the difference between Lite and Pro?**
+Lite caps the searchable history window at 12 months and omits the advanced map layers (heatmap,
+Fog of War, 3D globe), photo integrations, public sharing, and write access to the API. Pro removes
+the history cap and includes all of it.
+
+**Can I export my data?**
+Yes, at any time, on every plan — including Lite, where exports cover the full history rather than
+just the visible 12-month window.
+
+**What happens if Dawarich shuts down?**
+The project is open source (AGPLv3, 9,000+ GitHub stars). A self-hosted instance keeps running
+regardless, and data exports to standard formats.
+
+**Where is data stored?**
+For Cloud: European data centers, encrypted in transit and at rest, GDPR-compliant. For self-hosted:
+wherever you put it — it never reaches Dawarich servers.
+
+## Related pages
+
+- Pricing (HTML): https://dawarich.app/pricing/
+- Feature overview for agents: https://dawarich.app/features.md
+- Link index for agents: https://dawarich.app/llms.txt
+- Expanded content for agents: https://dawarich.app/llms-full.txt
+- Self-hosting: https://dawarich.app/docs/self-hosting/introduction
+- Refund policy: https://dawarich.app/refund-policy/
+- Terms: https://dawarich.app/terms-and-conditions/
+- Privacy policy: https://dawarich.app/privacy-policy/


### PR DESCRIPTION
## What

Publishes two pages as plain markdown at stable, guessable URLs, so agents can parse a document instead of an HTML page:

- **https://dawarich.app/pricing.md** — all three plans, per-day/per-month math, founding-price deadlines, the full Lite/Pro/Family comparison table, trial and refund terms, and the questions agents most often ask (starting with "is there a free tier?" — no, self-hosting is the free option)
- **https://dawarich.app/features.md** — tracking, map layers, visits and places, trips, stats, photo integrations, the full supported-import-format list, exports, API limits, and which features need a paid plan

Content is drawn from `src/data/pricingPlans.js`, the feature landing pages, and `docs/features/*` frontmatter — nothing invented.

## Why these two

They answer the two questions agents get asked about Dawarich most often, and both currently live in React pages with no markdown source, so an agent has to scrape rendered HTML to answer either one. `docs/` is already markdown on disk and could be mirrored later with a build script if this proves useful.

## Discovery

Via the new `llms.txt` entries and the guessable `.md` suffix — the two mechanisms agents demonstrably use today. No `<link rel="alternate" type="text/markdown">` tag: it's a plausible emerging convention with tooling forming around it, but there's no evidence any major agent reads it yet, so it stays out until it earns its place.

## Drift protection

`src/data/pricingMarkdownMirror.test.js` asserts that every price, founding-price deadline, plan feature label, and comparison-table row in `pricingPlans.js` also appears in `pricing.md`. Editing the pricing data without updating the mirror fails `npm test`.

Verified red-green: mutating the mirror (`119.99`→`129.99`, the deadline month, a renamed feature label) fails all four content assertions with the specific missing string.

## Also in here

- `static/_headers` — `text/plain` so browsers render the mirrors inline instead of downloading them (Cloudflare would otherwise send `text/markdown`, and `nosniff` is set), plus `X-Robots-Tag: noindex` so they don't compete with the HTML pages in search. Scoped to these two paths only.
- `llms.txt` — links both mirrors, and repoints the pricing entry from `https://dawarich.app/#pricing` to `https://dawarich.app/pricing/`. That anchor no longer exists, so agents following it were landing on the homepage and scrolling to nothing.

## Verification

```
Test Files  11 passed (11)      Tests  94 passed (94)
npm run build → [SUCCESS]
GET /pricing.md   → 200, correct raw body
GET /features.md  → 200, correct raw body
GET /pricing/     → 200 (no route collision)
```

## Needs a check after deploy

Cloudflare's `_headers` docs confirm `X-Robots-Tag` is settable but don't explicitly promise `Content-Type` can be overridden, and `docusaurus serve` doesn't apply `_headers` locally. Worth one `curl -sSI https://dawarich.app/pricing.md` once merged. If the override is ignored the files still serve fine as `text/markdown` — only the browser-rendering nicety is lost.

## Noticed, not fixed

- `docs/getting-started/export-your-data.md` says exports are OwnTracks-compatible JSON, while the FAQ and `llms.txt` say GPX and GeoJSON. The mirror follows the FAQ, but one of the two is stale.
- Four pages still link to the dead `#pricing` anchor (`/cloud/`, `/google-timeline-alternative/`, `/tools/`, `/docs/comparisons/vs-google-timeline/`) — the build warns about them.
