### PR TITLE
Launch the tools → signup handoff publicly

### DIFF
--- a/src/components/SaveToAccountButton.js
+++ b/src/components/SaveToAccountButton.js
@@ -1,7 +1,7 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import styles from './SaveToAccountButton.module.css';
 
-const API_BASE = 'https://staging.dawarich.app';
+const API_BASE = 'https://my.dawarich.app';
 const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
 
 const ERROR_MESSAGES = {
@@ -9,22 +9,6 @@ const ERROR_MESSAGES = {
   429: 'Too many uploads from your network. Please try again in an hour.',
   default: 'Upload failed. Please try again.',
 };
-
-/**
- * Dark-launch gate: the save-to-account UI only renders when the page is
- * opened with ?handoff=1 (checked client-side after hydration, so SSR and
- * first paint match). Lets the site deploy ahead of the backend endpoint
- * and enables testing against production before the public rollout.
- */
-export function useHandoffEnabled() {
-  const [enabled, setEnabled] = useState(false);
-
-  useEffect(() => {
-    setEnabled(new URLSearchParams(window.location.search).has('handoff'));
-  }, []);
-
-  return enabled;
-}
 
 function trackEvent(name) {
   if (typeof window !== 'undefined' && typeof window.sa_event === 'function') {

--- a/src/pages/privacy-policy.md
+++ b/src/pages/privacy-policy.md
@@ -24,6 +24,7 @@ This policy applies to the Dawarich SaaS at `dawarich.app`, the hosted tier, and
 | Error logs, crash reports, performance metrics | Keep the service stable and secure | (1)(f) legitimate interest |
 | Support correspondence | Respond to your requests | (1)(b) / (1)(f) |
 | Poster print orders (name, shipping address, email, phone, the poster file) | Produce and ship posters you order, invoicing | (1)(b) contract; (1)(c) legal obligation |
+| Files uploaded to the free tools with "Save to my Dawarich account" | Hold the file so it can be imported into the account you create next | (1)(b) pre-contractual measures at your request |
 
 The poster file you order is a map rendering of the location data you selected in the Poster Studio. It is shared with our payment and print partners (Section 3) solely to process and produce your order.
 
@@ -59,6 +60,9 @@ All listed processors are bound by DPAs under Art. 28 GDPR. We do not sell data 
 - **Billing data (including poster order records):** up to 10 years (§ 147 AO, § 257 HGB).
 - **Error logs:** up to 30 days.
 - **Support correspondence:** up to 3 years after last contact.
+- **Tool uploads awaiting an account:** deleted within 24 hours if you do not complete signup. Once claimed, the file becomes an import in your account and follows the account-data rule above.
+
+The free tools at `dawarich.app/tools/` process your files entirely in your browser by default; nothing is uploaded unless you press "Save to my Dawarich account".
 
 ## 5. Your Rights
 
@@ -97,10 +101,11 @@ We will notify you of **material changes** (new purposes, new processors, change
 
 ## Last updated
 
-Effective **2026-04-21**. Contact for all privacy matters: **hi@dawarich.app**.
+Effective **2026-07-28**. Contact for all privacy matters: **hi@dawarich.app**.
 
 | When          | What          |
 | ------------- | ------------- |
+| 2026-07-28    | Disclosed tool uploads held for signup ("Save to my Dawarich account") and their 24-hour deletion window |
 | 2026-07-18    | Added poster print orders: order data, Stripe and Gelato processors, print-file retention (48h unpaid / 90 days paid) |
 | 2026-04-21    | Added processor list, legal bases, rights, supervisory authority, transfers, cookie table; age to 16; reflected STORE_GEODATA=false; 30-day notice for material changes |
 | 2025-09-12    | Added TL;DR section |

--- a/src/pages/tools/google-timeline-converter.js
+++ b/src/pages/tools/google-timeline-converter.js
@@ -7,7 +7,7 @@ import { timelineToConverterPoints, timelineToCSV } from '@site/src/utils/timeli
 import { toGPX, toGeoJSON, toKML, toKMZ } from '@site/src/utils/formatConverters';
 import PersonalizedCTA from '@site/src/components/PersonalizedCTA';
 import RelatedTools from '@site/src/components/RelatedTools';
-import SaveToAccountButton, { useHandoffEnabled } from '@site/src/components/SaveToAccountButton';
+import SaveToAccountButton from '@site/src/components/SaveToAccountButton';
 import { detectGoogleSource } from '@site/src/utils/detectGoogleSource';
 import styles from './google-timeline-converter.module.css';
 
@@ -94,7 +94,6 @@ function formatDateRange(points, paths) {
 }
 
 export default function GoogleTimelineConverter() {
-  const handoffEnabled = useHandoffEnabled();
   const [uploadedFiles, setUploadedFiles] = useState([]);
   const [parsedResults, setParsedResults] = useState([]);
   const [allPoints, setAllPoints] = useState([]);
@@ -506,19 +505,17 @@ export default function GoogleTimelineConverter() {
                     )}
                   </div>
 
-                  {handoffEnabled && (
-                    <div className={styles.saveToAccountSection}>
-                      <p className={styles.saveToAccountIntro}>
-                        Want this in your Dawarich account too? We'll import it during signup — no second upload needed.
-                      </p>
-                      <SaveToAccountButton
-                        toolName="google-timeline-converter"
-                        sourceHint={detectGoogleSource(parsedResults)}
-                        getFiles={getOriginalFiles}
-                        disabled={!hasData}
-                      />
-                    </div>
-                  )}
+                  <div className={styles.saveToAccountSection}>
+                    <p className={styles.saveToAccountIntro}>
+                      Want this in your Dawarich account too? We'll import it during signup — no second upload needed.
+                    </p>
+                    <SaveToAccountButton
+                      toolName="google-timeline-converter"
+                      sourceHint={detectGoogleSource(parsedResults)}
+                      getFiles={getOriginalFiles}
+                      disabled={!hasData}
+                    />
+                  </div>
                 </>
               )}
 

--- a/src/pages/tools/gpx-merger.js
+++ b/src/pages/tools/gpx-merger.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import SaveToAccountButton, { useHandoffEnabled } from '@site/src/components/SaveToAccountButton';
+import SaveToAccountButton from '@site/src/components/SaveToAccountButton';
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 import { parseGPXDetailed, mergeGPXFiles, calculateMergeStats } from '@site/src/utils/gpxMerger';
@@ -13,7 +13,6 @@ const pageUrl = "https://dawarich.app/tools/gpx-merger/";
 const imageUrl = "https://dawarich.app/img/meta-image.png";
 
 export default function GPXMerger() {
-  const handoffEnabled = useHandoffEnabled();
   const [files, setFiles] = useState([]);
   const [parsedFiles, setParsedFiles] = useState([]);
   const [stats, setStats] = useState(null);
@@ -366,19 +365,17 @@ export default function GPXMerger() {
                 Merge & Download GPX
               </button>
 
-              {handoffEnabled && (
-                <div className={styles.saveToAccountSection}>
-                  <p className={styles.saveToAccountIntro}>
-                    Or skip the download — we'll merge and import it into your Dawarich account during signup.
-                  </p>
-                  <SaveToAccountButton
-                    toolName="gpx-merger"
-                    sourceHint="gpx"
-                    getFiles={getMergedFile}
-                    disabled={files.length < 2}
-                  />
-                </div>
-              )}
+              <div className={styles.saveToAccountSection}>
+                <p className={styles.saveToAccountIntro}>
+                  Or skip the download — we'll merge and import it into your Dawarich account during signup.
+                </p>
+                <SaveToAccountButton
+                  toolName="gpx-merger"
+                  sourceHint="gpx"
+                  getFiles={getMergedFile}
+                  disabled={files.length < 2}
+                />
+              </div>
             </div>
           )}
 

--- a/src/pages/tools/heatmap-generator.js
+++ b/src/pages/tools/heatmap-generator.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
-import SaveToAccountButton, { useHandoffEnabled } from '@site/src/components/SaveToAccountButton';
+import SaveToAccountButton from '@site/src/components/SaveToAccountButton';
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 import BrowserOnly from '@docusaurus/BrowserOnly';
@@ -305,7 +305,6 @@ function getColorRamp(scheme) {
 }
 
 export default function HeatmapGenerator() {
-  const handoffEnabled = useHandoffEnabled();
   const [files, setFiles] = useState([]);
   const [points, setPoints] = useState([]);
   const [stats, setStats] = useState(null);
@@ -498,7 +497,7 @@ export default function HeatmapGenerator() {
                 </div>
               )}
 
-              {handoffEnabled && files.length > 0 && (
+              {files.length > 0 && (
                 <div className={styles.saveToAccountSection}>
                   <p className={styles.saveToAccountIntro}>
                     Want this in your Dawarich account too? We'll import it during signup — no second upload needed.

--- a/src/pages/tools/timeline-mileage-calculator.js
+++ b/src/pages/tools/timeline-mileage-calculator.js
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useMemo } from 'react';
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 import FileUploader from '@site/src/components/FileUploader';
-import SaveToAccountButton, { useHandoffEnabled } from '@site/src/components/SaveToAccountButton';
+import SaveToAccountButton from '@site/src/components/SaveToAccountButton';
 import StatsCard from '@site/src/components/StatsCard';
 import { parseTimeline } from '@site/src/utils/timelineParser';
 import { generateMileageLog, mileageLogToCSV } from '@site/src/utils/timelineStats';
@@ -80,7 +80,6 @@ function formatActivityType(type) {
 }
 
 export default function TimelineMileageCalculator() {
-  const handoffEnabled = useHandoffEnabled();
   const [uploadedFiles, setUploadedFiles] = useState([]);
   const [allPoints, setAllPoints] = useState([]);
   const [allPaths, setAllPaths] = useState([]);
@@ -371,7 +370,7 @@ export default function TimelineMileageCalculator() {
             <div className={styles.uploaderWrapper}>
               <FileUploader onFilesLoaded={handleFilesLoaded} onClear={handleClear} />
 
-              {handoffEnabled && uploadedFiles.length > 0 && (
+              {uploadedFiles.length > 0 && (
                 <div className={styles.saveToAccountSection}>
                   <p className={styles.saveToAccountIntro}>
                     Want this in your Dawarich account too? We'll import it during signup — no second upload needed.

--- a/src/pages/tools/timeline-visualizer.js
+++ b/src/pages/tools/timeline-visualizer.js
@@ -4,7 +4,7 @@ import RelatedTools from '@site/src/components/RelatedTools';
 import Head from '@docusaurus/Head';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import FileUploader from '@site/src/components/FileUploader';
-import SaveToAccountButton, { useHandoffEnabled } from '@site/src/components/SaveToAccountButton';
+import SaveToAccountButton from '@site/src/components/SaveToAccountButton';
 import TimelinePanel from '@site/src/components/TimelinePanel/TimelinePanel';
 import { parseTimeline } from '@site/src/utils/timelineParser';
 import { SAMPLE_DAY } from '@site/src/utils/sampleBerlinData';
@@ -68,7 +68,6 @@ function nextMonthKey(monthKey, direction) {
 }
 
 export default function TimelineVisualizer() {
-  const handoffEnabled = useHandoffEnabled();
   const [uploadedFiles, setUploadedFiles] = useState([]);
   const [points, setPoints] = useState([]);
   const [paths, setPaths] = useState([]);
@@ -386,7 +385,7 @@ export default function TimelineVisualizer() {
           </div>
           <div className={styles.uploadRow}>
             <FileUploader onFilesLoaded={handleFilesLoaded} onClear={handleClear} />
-            {handoffEnabled && !isShowingSample && points.length > 0 && (
+            {!isShowingSample && points.length > 0 && (
               <div className={styles.saveToAccountSection}>
                 <p className={styles.saveToAccountIntro}>
                   Want this in your Dawarich account too? We'll import it during signup — no second upload needed.


### PR DESCRIPTION
Turns on the PendingImport claim-ticket flow for everyone. The backend has been in production since 1.10.0 (dawarich #2808, merged 2026-07-02); only the site was still gated.

## Changes

- `SaveToAccountButton.js`: `API_BASE` staging → `https://my.dawarich.app`
- Removed the `useHandoffEnabled` dark-launch hook and the `?handoff=1` gate from all five tools. Each tool keeps its own render guard (`files.length > 0`, `uploadedFiles.length > 0`, `!isShowingSample && points.length > 0`); the converter and gpx-merger blocks already sit inside `hasData` / `files.length > 0` parents, so they render unconditionally now.
- Privacy policy: new processing-table row for tool uploads (Art. 6(1)(b) pre-contractual measures), a retention bullet for the 24-hour deletion window, and a note that the tools are browser-only unless the button is pressed. Effective date and changelog updated.

## Why now

Tools are 37% of organic clicks (21,929 clicks / 16 months) and had no path into the product. This is the highest-ROI open item from the July GSC analysis.

## Verification

- `npm run build` succeeds
- Built bundle contains `my.dawarich.app/api/v1/imports/pending`; no `staging.dawarich.app` references remain in `build/assets/js/`
- Button server-renders on `/tools/google-timeline-converter/` without any query param

## Before merging

Confirm `SELF_HOSTED=false` is set on production — the constant defaults to `true` when unset, and the endpoint 404s on self-hosted:

```
curl -si -X POST https://my.dawarich.app/api/v1/imports/pending \
  -H "Origin: https://dawarich.app" -F "file=@/dev/null" | head -1
```

422/400 means live, 404 means the env var needs setting first. Related: dawarich #3210 normalises non-canonical `SELF_HOSTED` values and is not yet deployed.