### PR TITLE
Launch the Family plan on the pricing page and docs

### DIFF
--- a/docs/features/family.md
+++ b/docs/features/family.md
@@ -8,8 +8,33 @@ description: Share your real-time location with trusted family members and frien
 
 The Family feature allows you to share your real-time location with trusted family members and friends. This enables you to see each other's locations on the map while maintaining full control over your privacy.
 
+The feature is available on **self-hosted** instances for everyone, and on **Dawarich Cloud** through the [Family plan](#family-plan-dawarich-cloud).
+
+## Family plan (Dawarich Cloud)
+
+On Dawarich Cloud, creating and owning a family requires the **Family plan**. It is a single annual subscription that covers a whole household:
+
+- **€299.99 / year**, annual billing only (like Lite).
+- **Up to 5 members total** — the owner (payer) plus up to 4 invited members.
+- **Every member gets full Pro access** — unlimited history, heatmap, Fog of War, globe view, photo/Immich/PhotoPrism integrations, full write API — for as long as they are in the family. Invited members do **not** need their own paid subscription.
+- **Members inherit access automatically.** Access is computed at read time from family membership, so it is granted the moment a member joins and revoked the moment they leave, are removed, or the owner's subscription ends. There is no separate per-member billing.
+- **Your data is never deleted.** When a member leaves (or the plan ends) their access reverts to their own plan, but every point they recorded stays in their account and remains fully exportable.
+
+### Who needs the plan
+
+- **The owner** (the person who creates the family and pays) needs the Family plan.
+- **Invited members** join for free and inherit full access while in the family — joining is never gated on their own plan.
+
+### Upgrading to Family
+
+If you are on Lite or Pro, you can switch to Family from your subscription page; Paddle charges a prorated amount for the remainder of your current period. Self-hosted instances have all family features without any plan.
+
+### If the owner cancels
+
+The family stays intact and dormant — members simply revert to their own plans (Lite or Pro), and can regain full access if the owner re-subscribes. No family data is lost.
+
 :::info
-The Family feature is currently only available for self-hosted instances of Dawarich.
+Self-hosted instances have every family feature with no plan and no member cap beyond the app's built-in limit.
 :::
 
 ## Overview

--- a/src/components/PricingCompare.js
+++ b/src/components/PricingCompare.js
@@ -3,9 +3,9 @@ import { COMPARE_GROUPS, DwIcon, PLANS } from "@site/src/data/pricingPlans";
 import styles from "./PricingCompare.module.css";
 
 const COLS = [
-	{ key: "lite", name: "Lite", sub: `€/yr`, accent: "blue", popular: false },
-	{ key: "pro", name: "Pro", sub: `€/yr`, accent: "blue", popular: true },
-	{ key: "family", name: "Family", sub: "Coming soon", accent: "teal", popular: false },
+	{ key: "lite", name: "Lite", sub: `€${PLANS.lite.price}/yr`, accent: "blue", popular: false },
+	{ key: "pro", name: "Pro", sub: `€${PLANS.pro.price}/yr`, accent: "blue", popular: true },
+	{ key: "family", name: "Family", sub: `€${PLANS.family.price}/yr`, accent: "teal", popular: false },
 ];
 
 // Comparison table gets its own UTM tagging, distinct from the pricing cards
@@ -14,7 +14,7 @@ const COMPARE_UTM = "utm_source=site&utm_medium=pricing_compare";
 const CTA_LINKS = {
 	lite: `https://my.dawarich.app/users/sign_up?${COMPARE_UTM}&utm_campaign=try7dayslite&utm_content=compare_lite&plan=lite`,
 	pro: `https://my.dawarich.app/users/sign_up?${COMPARE_UTM}&utm_campaign=try7days&utm_content=compare_pro`,
-	family: "#pricing",
+	family: `https://my.dawarich.app/users/sign_up?${COMPARE_UTM}&utm_campaign=try7daysfamily&utm_content=compare_family&plan=family`,
 };
 
 const norm = (v) => (v === true ? "✓" : v === false ? "✗" : String(v));
@@ -188,11 +188,7 @@ export default function PricingCompare() {
 										href={CTA_LINKS[c.key]}
 										className={`${styles.footCta} ${c.popular ? styles.footCtaPrimary : c.accent === "teal" ? styles.footCtaTeal : styles.footCtaBlue}`}
 									>
-										{c.key === "family"
-											? "Notify me"
-											: c.key === "pro"
-												? "Start free"
-												: "Choose Lite"}
+										{c.key === "lite" ? "Choose Lite" : "Start free"}
 									</a>
 								</div>
 							))}

--- a/src/components/PricingSection.js
+++ b/src/components/PricingSection.js
@@ -27,7 +27,7 @@ export default function PricingSection() {
 						<PricingCard plan={PLANS.pro} popular />
 					</div>
 					<div className={styles.cardWrapper}>
-						<PricingCard plan={PLANS.family} deemph />
+						<PricingCard plan={PLANS.family} />
 					</div>
 				</div>
 

--- a/src/data/pricingPlans.js
+++ b/src/data/pricingPlans.js
@@ -149,9 +149,12 @@ export const PLANS = {
 		period: "/year",
 		perMonth: "€25.00/month",
 		perDay: "€0.82/day",
-		badge: "COMING SOON",
+		badge: null,
+		cta: "Start Family Free — 7 Days",
+		ctaStyle: "outline",
+		href: `${SIGNUP}&utm_campaign=try7daysfamily&plan=family`,
+		footnote: "Annual only · Up to 5 members · Cancel anytime",
 		urgency: null,
-		waitlistListId: "dawarichfamilywaitlist",
 		valueStack: {
 			items: [
 				{ label: "Pro access for the payer", value: 180 },

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -16,7 +16,7 @@ export default function PricingPage() {
 	return (
 		<Layout
 			title="Pricing — Dawarich"
-			description="Simple pricing for Dawarich Cloud. Lite €59.99/yr or Pro €17.99/mo. 7-day free trial, 14-day risk-free refund, cancel anytime. Or self-host for free."
+			description="Simple pricing for Dawarich Cloud. Lite €59.99/yr, Pro €17.99/mo, or Family €299.99/yr for up to 5 people. 7-day free trial, 14-day risk-free refund, cancel anytime. Or self-host for free."
 		>
 			<Head>
 				<meta property="og:type" content="website" />
@@ -24,7 +24,7 @@ export default function PricingPage() {
 				<meta property="og:title" content="Pricing — Dawarich" />
 				<meta
 					property="og:description"
-					content="Lite €59.99/yr or Pro €17.99/mo. 7-day free trial, 14-day risk-free refund. Or self-host for free."
+					content="Lite €59.99/yr, Pro €17.99/mo, or Family €299.99/yr for up to 5 people. 7-day free trial, 14-day risk-free refund. Or self-host for free."
 				/>
 				<meta
 					property="og:image"
@@ -34,7 +34,7 @@ export default function PricingPage() {
 				<meta name="twitter:title" content="Pricing — Dawarich" />
 				<meta
 					name="twitter:description"
-					content="Lite €59.99/yr or Pro €17.99/mo. 7-day free trial, 14-day risk-free refund. Or self-host for free."
+					content="Lite €59.99/yr, Pro €17.99/mo, or Family €299.99/yr for up to 5 people. 7-day free trial, 14-day risk-free refund. Or self-host for free."
 				/>
 				<meta
 					name="twitter:image"
@@ -82,7 +82,7 @@ export default function PricingPage() {
 									"One annual subscription covering up to 5 members, each with full Pro access.",
 								price: "299.99",
 								priceCurrency: "EUR",
-								availability: "https://schema.org/PreOrder",
+								availability: "https://schema.org/InStock",
 								url: "https://dawarich.app/pricing/",
 							},
 							{


### PR DESCRIPTION
The Family plan has been buyable in-app since the flag flip on 2026-07-31 — this brings the website in line:

- Pricing card: drop the COMING SOON badge and waitlist, add the trial CTA linking to signup with `plan=family`
- Compare table: real prices in the column headers (fixes the empty `€/yr` on Lite/Pro), Family column links to signup instead of the waitlist anchor
- JSON-LD: Family offer `PreOrder` → `InStock`
- Meta/OG descriptions now mention Family €299.99/yr
- `docs/features/family.md`: new section describing the Cloud Family plan (pricing, seats, access inheritance, owner-cancel behavior)