### PR TITLE
feat: add Partnero affiliate tracking

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -90,6 +90,23 @@ const config = {
         });
       `,
     },
+    // Partnero affiliate tracking. Reads ?via=PARTNER_KEY and stores it in a
+    // first-party cookie on dawarich.app. That cookie does not reach
+    // my.dawarich.app, so src/utils/utm.js also appends `via` to outbound CTAs
+    // and PartneroJS on the app re-reads it there.
+    {
+      tagName: "script",
+      attributes: {},
+      innerHTML: `
+        (function(p,t,n,e,r,o){ p['__partnerObject']=r;function f(){
+        var c={ a:arguments,q:[]};var r=this.push(c);return "number"!=typeof r?r:f.bind(c.q);}
+        f.q=f.q||[];p[r]=p[r]||f.bind(f.q);p[r].q=p[r].q||f.q;o=t.createElement(n);
+        var _=t.getElementsByTagName(n)[0];o.async=1;o.src=e+'?v'+(~~(new Date().getTime()/1e6));
+        _.parentNode.insertBefore(o,_);})(window, document, 'script', 'https://app.partnero.com/js/universal.js', 'po');
+        po('settings', 'assets_host', 'https://assets.partnero.com');
+        po('program', '1NNVU1NU', 'load');
+      `,
+    },
   ],
 
   onBrokenLinks: 'throw',

--- a/src/utils/utm.js
+++ b/src/utils/utm.js
@@ -10,11 +10,23 @@
  * 3. If no external UTM params exist, internal UTM params work normally
  *
  * This solution is UNIVERSAL - it automatically applies to all external links on the site.
+ *
+ * It also carries the Partnero affiliate key (`via`) to the app. PartneroJS stores
+ * that key in a first-party cookie scoped to dawarich.app, which is never sent to
+ * my.dawarich.app where signup happens — the same subdomain gap the gtag linker in
+ * docusaurus.config.js works around for gclid. Appending `via` to outbound links lets
+ * PartneroJS on the app re-read it from the URL and set its own cookie there.
  */
 
 const UTM_PARAMS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content'];
 const STORAGE_KEY = 'original_utm_params';
 const STORAGE_DURATION = 30 * 24 * 60 * 60 * 1000; // 30 days in milliseconds
+
+const REFERRAL_PARAM = 'via';
+const REFERRAL_STORAGE_KEY = 'partnero_referral';
+// Keep at or above the cookie lifetime configured in the Partnero program, otherwise
+// the site stops forwarding a key that Partnero would still have honoured.
+const REFERRAL_STORAGE_DURATION = 90 * 24 * 60 * 60 * 1000; // 90 days in milliseconds
 
 /**
  * Get UTM parameters from URL
@@ -57,6 +69,58 @@ export function saveOriginalUtmParams() {
 }
 
 /**
+ * Save the Partnero affiliate key from the URL.
+ *
+ * Unlike UTM params this is last-touch: a visitor arriving through a newer affiliate
+ * link overwrites the stored key. Partnero owns the attribution rule and computes
+ * commissions from its own cookie, so the site forwards whichever key the visitor
+ * actually arrived with rather than imposing a first-touch policy Partnero never saw.
+ */
+export function saveReferralKey() {
+  if (typeof window === 'undefined') return;
+
+  const key = new URLSearchParams(window.location.search).get(REFERRAL_PARAM);
+  if (!key) return;
+
+  localStorage.setItem(
+    REFERRAL_STORAGE_KEY,
+    JSON.stringify({ key, timestamp: Date.now() })
+  );
+}
+
+/**
+ * Get the stored Partnero affiliate key, or null if absent or expired
+ */
+export function getReferralKey() {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    const stored = localStorage.getItem(REFERRAL_STORAGE_KEY);
+    if (!stored) return null;
+
+    const data = JSON.parse(stored);
+
+    if (Date.now() - data.timestamp > REFERRAL_STORAGE_DURATION) {
+      localStorage.removeItem(REFERRAL_STORAGE_KEY);
+      return null;
+    }
+
+    return data.key || null;
+  } catch (e) {
+    return null;
+  }
+}
+
+/**
+ * Clear the stored Partnero affiliate key (useful for testing or user logout)
+ */
+export function clearReferralKey() {
+  if (typeof window !== 'undefined') {
+    localStorage.removeItem(REFERRAL_STORAGE_KEY);
+  }
+}
+
+/**
  * Get saved original UTM parameters if still valid
  */
 function getOriginalUtmParams() {
@@ -92,7 +156,7 @@ function getOriginalUtmParams() {
  * @param {string} urlString - The URL to append params to
  * @returns {string} URL with UTM parameters
  */
-export function buildUrlWithUtm(urlString) {
+export function buildOutboundUrl(urlString) {
   if (typeof window === 'undefined') return urlString;
 
   try {
@@ -114,6 +178,13 @@ export function buildUrlWithUtm(urlString) {
     // If no original params exist, keep the internal UTM params as-is
     // (they're already in the URL - no changes needed)
 
+    // A `via` already on the link is an explicit choice by whoever authored it
+    // and outranks the stored key.
+    const referralKey = getReferralKey();
+    if (referralKey && !url.searchParams.has(REFERRAL_PARAM)) {
+      url.searchParams.set(REFERRAL_PARAM, referralKey);
+    }
+
     return url.toString();
   } catch (e) {
     return urlString;
@@ -127,8 +198,9 @@ export function buildUrlWithUtm(urlString) {
 export function initializeUtmPreservation() {
   if (typeof window === 'undefined') return;
 
-  // Save UTM params on page load
+  // Save UTM params and any affiliate key on page load
   saveOriginalUtmParams();
+  saveReferralKey();
 
   // Intercept all clicks on external links
   document.addEventListener('click', (e) => {
@@ -138,13 +210,13 @@ export function initializeUtmPreservation() {
     const href = link.getAttribute('href');
     if (!href) return;
 
-    // Check if it's an external link with UTM params
+    // Rewrite external links carrying UTM params, and any external link at all once
+    // an affiliate key is stored — CTAs without utm_ still need to carry `via`.
     const isExternal = href.startsWith('http://') || href.startsWith('https://');
     const hasUtmParams = href.includes('utm_');
 
-    if (isExternal && hasUtmParams) {
-      // Update the href with preserved UTM params
-      const newHref = buildUrlWithUtm(href);
+    if (isExternal && (hasUtmParams || getReferralKey())) {
+      const newHref = buildOutboundUrl(href);
       if (newHref !== href) {
         link.setAttribute('href', newHref);
       }

--- a/src/utils/utm.test.js
+++ b/src/utils/utm.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  buildOutboundUrl,
+  saveOriginalUtmParams,
+  clearOriginalUtmParams,
+  saveReferralKey,
+  getReferralKey,
+  clearReferralKey,
+} from './utm';
+
+const SIGNUP = 'https://my.dawarich.app/users/sign_up';
+
+function visit(search) {
+  window.history.replaceState({}, '', `/${search}`);
+}
+
+describe('referral (via) preservation', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    clearOriginalUtmParams();
+    clearReferralKey();
+    visit('');
+  });
+
+  it('saves the via key when a visitor lands from a referral link', () => {
+    visit('?via=PARTNER123');
+    saveReferralKey();
+
+    expect(getReferralKey()).toBe('PARTNER123');
+  });
+
+  it('appends the saved via key to an outbound signup URL', () => {
+    visit('?via=PARTNER123');
+    saveReferralKey();
+
+    expect(buildOutboundUrl(SIGNUP)).toContain('via=PARTNER123');
+  });
+
+  it('appends via even when the outbound URL carries no utm params', () => {
+    visit('?via=PARTNER123');
+    saveReferralKey();
+
+    const url = new URL(buildOutboundUrl('https://my.dawarich.app/users/sign_in'));
+    expect(url.searchParams.get('via')).toBe('PARTNER123');
+  });
+
+  it('survives later navigation that carries no via of its own', () => {
+    visit('?via=PARTNER123');
+    saveReferralKey();
+
+    visit('?utm_source=blog');
+    saveReferralKey();
+
+    expect(getReferralKey()).toBe('PARTNER123');
+  });
+
+  it('takes the newest via so Partnero decides attribution, not the site', () => {
+    visit('?via=FIRST');
+    saveReferralKey();
+
+    visit('?via=SECOND');
+    saveReferralKey();
+
+    expect(getReferralKey()).toBe('SECOND');
+  });
+
+  it('leaves URLs untouched when no referral was ever seen', () => {
+    expect(buildOutboundUrl(SIGNUP)).toBe(SIGNUP);
+  });
+
+  it('does not clobber an explicit via already present on the link', () => {
+    visit('?via=STORED');
+    saveReferralKey();
+
+    const url = new URL(buildOutboundUrl(`${SIGNUP}?via=EXPLICIT`));
+    expect(url.searchParams.get('via')).toBe('EXPLICIT');
+  });
+
+  it('preserves via and utm params together', () => {
+    visit('?via=PARTNER123&utm_source=blog&utm_medium=post');
+    saveReferralKey();
+    saveOriginalUtmParams();
+
+    const url = new URL(buildOutboundUrl(`${SIGNUP}?utm_source=hero`));
+    expect(url.searchParams.get('via')).toBe('PARTNER123');
+    expect(url.searchParams.get('utm_source')).toBe('blog');
+  });
+
+  it('drops a referral once it has aged past the retention window', () => {
+    visit('?via=PARTNER123');
+    saveReferralKey();
+
+    const stored = JSON.parse(localStorage.getItem('partnero_referral'));
+    stored.timestamp = Date.now() - (91 * 24 * 60 * 60 * 1000);
+    localStorage.setItem('partnero_referral', JSON.stringify(stored));
+
+    expect(getReferralKey()).toBeNull();
+  });
+});


### PR DESCRIPTION
Loads PartneroJS on the marketing site and carries the affiliate key through to signup. Part of the Partnero affiliate program (program `1NNVU1NU`); the companion change lives in the Dawarich app.

## Why the UTM utility changed too

PartneroJS stores the referral in a **first-party cookie scoped to the host that set it**. A key captured on `dawarich.app` is therefore never sent to `my.dawarich.app`, which is where signup actually happens — the same subdomain gap the gtag linker in `docusaurus.config.js` already documents for `gclid`.

So the snippet alone captures nothing usable. `src/utils/utm.js` now also persists the `via` key and appends it to outbound CTAs, letting PartneroJS on the app re-read it from the URL and set its own cookie there.

Two details worth reviewing:

- The existing click interceptor only rewrote hrefs that **already contained `utm_`**. Any CTA without UTM params would have silently dropped `via`, so that condition is relaxed once a referral is stored.
- `via` is **last-touch**, unlike the first-touch rule used for UTM params. Partnero owns the attribution policy and computes commissions from its own cookie; the site forwards whichever key the visitor actually arrived with rather than silently imposing a different policy.

Note the referral param is `via`, not `ref` — affiliate links are `https://dawarich.app/?via=CODE`.

## Testing

- New `src/utils/utm.test.js` — 9 cases covering capture, forwarding to CTAs with and without UTM params, last-touch overwrite, persistence across navigation, explicit-`via` precedence, and expiry.
- Full suite: 103 tests across 12 files, 0 failures.
- `npm run build` succeeds; verified the snippet renders inside `<head>` in `build/index.html` with program ID intact (the minifier inlines the loader URL and passes `0` for the now-dead parameter, which is a safe fold).
