### PR TITLE
feat: load Partnero on consent and disclose it as a processor

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -90,23 +90,6 @@ const config = {
         });
       `,
     },
-    // Partnero affiliate tracking. Reads ?via=PARTNER_KEY and stores it in a
-    // first-party cookie on dawarich.app. That cookie does not reach
-    // my.dawarich.app, so src/utils/utm.js also appends `via` to outbound CTAs
-    // and PartneroJS on the app re-reads it there.
-    {
-      tagName: "script",
-      attributes: {},
-      innerHTML: `
-        (function(p,t,n,e,r,o){ p['__partnerObject']=r;function f(){
-        var c={ a:arguments,q:[]};var r=this.push(c);return "number"!=typeof r?r:f.bind(c.q);}
-        f.q=f.q||[];p[r]=p[r]||f.bind(f.q);p[r].q=p[r].q||f.q;o=t.createElement(n);
-        var _=t.getElementsByTagName(n)[0];o.async=1;o.src=e+'?v'+(~~(new Date().getTime()/1e6));
-        _.parentNode.insertBefore(o,_);})(window, document, 'script', 'https://app.partnero.com/js/universal.js', 'po');
-        po('settings', 'assets_host', 'https://assets.partnero.com');
-        po('program', '1NNVU1NU', 'load');
-      `,
-    },
   ],
 
   onBrokenLinks: 'throw',

--- a/src/components/CookieConsent.js
+++ b/src/components/CookieConsent.js
@@ -29,6 +29,30 @@ export default function CustomCookieConsent() {
         }
       ]);
     };
+
+    // Affiliate attribution. The cookie this sets is not strictly necessary
+    // under § 25 TTDSG, so it waits for consent like the two above. Attribution
+    // itself does not depend on it — the `via` key travels to the app on the
+    // CTA URL (see src/utils/utm.js), so declining costs Partnero only its own
+    // click statistics.
+    (function (p, t, n, e, r, o) {
+      p['__partnerObject'] = r;
+      function f() {
+        var c = { a: arguments, q: [] };
+        var r = this.push(c);
+        return typeof r != "number" ? r : f.bind(c.q);
+      }
+      f.q = f.q || [];
+      p[r] = p[r] || f.bind(f.q);
+      p[r].q = p[r].q || f.q;
+      o = t.createElement(n);
+      var _ = t.getElementsByTagName(n)[0];
+      o.async = 1;
+      o.src = e + '?v' + (~~(new Date().getTime() / 1e6));
+      _.parentNode.insertBefore(o, _);
+    })(window, document, 'script', 'https://app.partnero.com/js/universal.js', 'po');
+    window.po('settings', 'assets_host', 'https://assets.partnero.com');
+    window.po('program', '1NNVU1NU', 'load');
   };
 
   const buttonStyle = {
@@ -68,8 +92,8 @@ export default function CustomCookieConsent() {
       onAccept={handleAccept}
     >
       We use a cookieless analytics service (Simple Analytics) that requires no consent.
-      You can optionally accept cookies for Google Ads conversion tracking and Brevo email
-      analytics — these only load if you click "Accept".
+      You can optionally accept cookies for Google Ads conversion tracking, Brevo email
+      analytics and affiliate referral credit — these only load if you click "Accept".
       <a
         href="/privacy-policy#cookies"
         style={{

--- a/src/pages/privacy-policy.md
+++ b/src/pages/privacy-policy.md
@@ -50,6 +50,7 @@ All listed processors are bound by DPAs under Art. 28 GDPR. We do not sell data 
 | Google LLC | Google Play distribution | United States |
 | Stripe Payments Europe, Ltd. | Payment processing for poster print orders | Ireland (EU); parent Stripe, Inc. (US) |
 | Gelato ASA | Poster printing and shipping (receives shipping details and the poster file) | Norway (EEA); production within the EU |
+| Partnero, Inc. | Affiliate-referral attribution — receives your email and name only if you arrived via an affiliate link | United States |
 
 **International transfers:** UK (Paddle) is covered by the EU adequacy decision. Norway (Gelato) is in the EEA, where the GDPR applies directly. US transfers rely on the EU-US Data Privacy Framework where the provider is certified, and on Standard Contractual Clauses (Art. 46 GDPR) otherwise.
 
@@ -80,6 +81,7 @@ On `dawarich.app` we use:
 | Cookieless analytics | Aggregate traffic | No | Simple Analytics |
 | Advertising | Google Ads conversion tracking | **Yes** | Google Ads |
 | Email analytics | Brevo tracking pixel | **Yes** | Brevo |
+| Affiliate attribution | Credit a referring partner for a sign-up | **Yes** | Partnero |
 
 To withdraw consent after accepting, delete the `dawarichCookieConsent` cookie and reload. On `my.dawarich.app` we additionally use first-party session cookies strictly necessary for login.
 
@@ -101,10 +103,11 @@ We will notify you of **material changes** (new purposes, new processors, change
 
 ## Last updated
 
-Effective **2026-07-28**. Contact for all privacy matters: **hi@dawarich.app**.
+Effective **2026-08-12**. Contact for all privacy matters: **hi@dawarich.app**.
 
 | When          | What          |
 | ------------- | ------------- |
+| 2026-08-12    | Added Partnero as a processor for affiliate-referral attribution, and the affiliate cookie to the cookie table |
 | 2026-07-28    | Disclosed tool uploads held for signup ("Save to my Dawarich account") and their 24-hour deletion window |
 | 2026-07-18    | Added poster print orders: order data, Stripe and Gelato processors, print-file retention (48h unpaid / 90 days paid) |
 | 2026-04-21    | Added processor list, legal bases, rights, supervisory authority, transfers, cookie table; age to 16; reflected STORE_GEODATA=false; 30-day notice for material changes |


### PR DESCRIPTION
Follow-up to #54, which shipped the tracking snippet in `headTags` where it loaded on every page unconditionally.

## Consent

The affiliate cookie is not strictly necessary under § 25 TTDSG, so it needs consent like Google Ads and Brevo. The banner already promises those "only load if you click Accept" — the Partnero snippet was contradicting that. It moves out of `headTags` into `handleAccept` alongside the other two, and the banner copy now names it.

Attribution does not depend on that cookie. The `via` key travels to the app on the CTA URL (`src/utils/utm.js`), and the app registers the referral server-side, so declining costs Partnero only its own click statistics — not the commission.

## Privacy policy

- **Partnero, Inc.** added to the §3 processor table. Verified against their privacy policy: Delaware corporation, 228 Park Ave S PMB 54955, New York.
- Affiliate cookie added to the §6 cookie table as consent-required.
- Effective date bumped and a row added to the policy's own change log.

US transfers are already covered by the existing clause — Partnero claims no Data Privacy Framework certification, so the Standard Contractual Clauses branch applies via their DPA.

## Testing

- 103 tests across 12 files pass; `npm run build` succeeds.
- Verified in `build/index.html` that `partnero` no longer appears anywhere in the static HTML, and that the loader is present in the JS bundle so it still fires on Accept.
