### PR TITLE
Retarget Timeline Visualizer at stranded Google Timeline searchers

### DIFF
--- a/blog/2024-10-23-migrating-from-google-location-history-to-dawarich.md
+++ b/blog/2024-10-23-migrating-from-google-location-history-to-dawarich.md
@@ -20,6 +20,8 @@ The least you can do is to export your data from Google. You can do it either us
 
 <!-- truncate -->
 
+If you want to inspect your export before importing it anywhere, the free [Google Timeline Visualizer](/tools/timeline-visualizer/) shows it on a map right in your browser, and the [Google Timeline Converter](/tools/google-timeline-converter/) turns it into GPX, KML, or GeoJSON.
+
 ## What's next?
 
 That's where Dawarich comes in very handy. Although Google lacks consistency when it comes to the export file format, Dawarich already supports all three (3) kinds of files that you can get from Google.

--- a/blog/2026-03-28-what-s-inside-your-google-timeline-export.md
+++ b/blog/2026-03-28-what-s-inside-your-google-timeline-export.md
@@ -11,6 +11,10 @@ I maintain [Dawarich](https://dawarich.app), which imports all of these formats,
 
 <!-- truncate -->
 
+:::tip Just want to look at your data?
+Drop your export into the free [Google Timeline Visualizer](/tools/timeline-visualizer/) to see it on a map, or turn it into GPX, KML, or GeoJSON with the [Google Timeline Converter](/tools/google-timeline-converter/) — both run entirely in your browser.
+:::
+
 ## Three formats, one mess
 
 Google has shipped three different export formats over the years. Which one you get depends on when you exported, how you exported, and seemingly what mood their servers were in that day. Some people get one, some get all three. So the first thing is figuring out what you're dealing with.

--- a/src/pages/tools/timeline-visualizer.js
+++ b/src/pages/tools/timeline-visualizer.js
@@ -13,8 +13,8 @@ import styles from './timeline-visualizer.module.css';
 
 const TimelineMapV2 = lazy(() => import('@site/src/components/TimelineMapV2'));
 
-const pageTitle = "Google Timeline Visualizer - View Your Location History as a Calendar";
-const pageDescription = "Free, privacy-first Google Timeline visualizer. Browse your location history day-by-day with a calendar heat-grid, visit list, journey legs, and activity replay. All processing happens in your browser.";
+const pageTitle = "Google Timeline Visualizer — View Your Timeline on the Web Again";
+const pageDescription = "Google removed Timeline from the web. This free visualizer brings it back: upload your Takeout export and see your location history on a map, in your browser.";
 const pageUrl = "https://dawarich.app/tools/timeline-visualizer/";
 const imageUrl = "https://dawarich.app/img/meta-image.png";
 
@@ -30,6 +30,14 @@ const faqItems = [
   {
     question: "Why did Google shut down Timeline on the web?",
     answer: "In late 2024, Google discontinued the web-based version of Google Maps Timeline and moved all location data to on-device storage. Users' last 90 days of data were transferred to their phone, but older data was deleted unless manually backed up. Many users lost years of location history in the transition. This visualizer helps you view and explore any Google Timeline data you managed to export."
+  },
+  {
+    question: "Where did my Google Timeline go?",
+    answer: "If Timeline disappeared from Google Maps in your browser, it's not just you — Google removed the web version and moved Timeline on-device. Your history now lives in the Google Maps app on your phone (tap your profile picture → Timeline). If it's missing there too, look for an older Google Takeout archive or a Timeline backup — any export you still have can be uploaded here to see your full history again."
+  },
+  {
+    question: "How can I view my Google Timeline on the web again?",
+    answer: "Export your Timeline data from your phone (Google Maps → Settings → Location → Timeline → Export Timeline data) or from Google Takeout, then upload the JSON files to this visualizer. You get a web-based timeline again — calendar, map, and day-by-day details — with no Google account needed. To keep a permanent, always-up-to-date timeline, you can import the same files into Dawarich."
   },
   {
     question: "How do I export my Google Timeline data?",
@@ -252,7 +260,7 @@ export default function TimelineVisualizer() {
         {/* Primary Meta Tags */}
         <meta name="title" content={pageTitle} />
         <meta name="description" content={pageDescription} />
-        <meta name="keywords" content="Google Timeline visualizer, Google location history viewer, Google Takeout location viewer, view location history on map, Google Maps Timeline replacement, Google Timeline shutdown alternative, location history map, Google Timeline export viewer, privacy-first location visualizer" />
+        <meta name="keywords" content="Google Timeline visualizer, Google Timeline gone, where is my Google Timeline, view Google Timeline on the web, Google Timeline history, Google location history viewer, Google Takeout location viewer, view location history on map, Google Maps Timeline replacement, Google Timeline shutdown alternative, location history map, Google Timeline export viewer, privacy-first location visualizer" />
         <link rel="canonical" href={pageUrl} />
 
         {/* Open Graph / Facebook */}
@@ -382,7 +390,7 @@ export default function TimelineVisualizer() {
         <div className={styles.heroSection}>
           <div className={styles.header}>
             <h1>Google Timeline Visualizer</h1>
-            <p>Free, privacy-first tool to visualize your Google Timeline location history. Browse day by day with a calendar heat-grid, visit list, and activity replay.</p>
+            <p>Google shut down Timeline on the web — this free, privacy-first tool brings the view back. Browse your exported location history day by day with a calendar heat-grid, visit list, and activity replay.</p>
           </div>
           <div className={styles.uploadRow}>
             <FileUploader onFilesLoaded={handleFilesLoaded} onClear={handleClear} />
@@ -432,6 +440,9 @@ export default function TimelineVisualizer() {
                       <p>Open Google Maps → Settings → Personal Content → Export Timeline data</p>
                     </div>
                   </div>
+                  <p>
+                    Already have your export? You can also convert it to GPX, KML, or GeoJSON with the free <a href="/tools/google-timeline-converter/">Google Timeline Converter</a>.
+                  </p>
                 </div>
               </details>
             </div>


### PR DESCRIPTION
## Why

GSC (3 months to 2026-08-12): the queries **"google timeline"** and **"google timeline history"** generate ~38k impressions but only 0.1–0.3% CTR. The visualizer serves them at position ~8.6 with a title that doesn't speak to why these people are searching — Google removed Timeline from the web and they want it back. Meanwhile `/tools/google-timeline-converter/` converts at 18.5% CTR (pos 4.7) but is under-impressed at only 1.3k impressions/3mo.

## What

- Visualizer title → **"Google Timeline Visualizer — View Your Timeline on the Web Again"**. The phrase "Google Timeline Visualizer" stays contiguous: the branded query runs 28.9% CTR at pos 1.8 and must not regress.
- New 159-char meta description and hero copy lead with the shutdown.
- Two new FAQ items, automatically included in the existing FAQPage JSON-LD: *"Where did my Google Timeline go?"* and *"How can I view my Google Timeline on the web again?"*
- Contextual links to the Google Timeline Converter from the visualizer's export instructions and from two timeline blog posts (added below the `<!-- truncate -->` marker, so blog-index excerpts are unchanged).

## Verification

`npm run build` green; new title, meta, FAQ (visible + JSON-LD) and links confirmed present in the built HTML. The four `#pricing` broken-anchor warnings are pre-existing and unrelated.

## Measure

Re-check GSC CTR on "google timeline" / "google timeline history" at 2 and 4 weeks against the 0.1% / 0.3% baseline.
