### PR TITLE
fix: restore valid JSON in package.json overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "overrides": {
     "picomatch": "^4.0.3",
-    "websocket-driver": "0.7.5"
+    "websocket-driver": "0.7.5",
     "shell-quote": "1.8.4"
   }
 }


### PR DESCRIPTION
`package.json` on `main` does not parse — the `websocket-driver` override lost its trailing comma when #56 merged main in alongside #53's `shell-quote` override:

```json
"websocket-driver": "0.7.5"
"shell-quote": "1.8.4"
```

`npm install`, `npm run build` and the Cloudflare Pages deploy all fail on main until this lands. One character.

Worth a look at how it got through: #56 came from a fork, and fork PRs skip parts of CI here, so a green tick did not mean the build ran.