### PR TITLE
fix: accept both aff and via as the Partnero referral param

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "overrides": {
     "picomatch": "^4.0.3",
-    "websocket-driver": "0.7.5"
+    "websocket-driver": "0.7.5",
     "shell-quote": "1.8.4"
   }
 }

--- a/src/utils/utm.js
+++ b/src/utils/utm.js
@@ -22,7 +22,12 @@ const UTM_PARAMS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm
 const STORAGE_KEY = 'original_utm_params';
 const STORAGE_DURATION = 30 * 24 * 60 * 60 * 1000; // 30 days in milliseconds
 
-const REFERRAL_PARAM = 'via';
+// Partnero's referral param is configured per program — their docs describe
+// `via`, the snippet generated for this program emits `aff`. Both are read so a
+// dashboard setting cannot silently cost every commission; `aff` wins because
+// that is what the program's own snippet writes. The key is forwarded under the
+// param it arrived on, so the app sees exactly what Partnero produced.
+const REFERRAL_PARAMS = ['aff', 'via'];
 const REFERRAL_STORAGE_KEY = 'partnero_referral';
 // Keep at or above the cookie lifetime configured in the Partnero program, otherwise
 // the site stops forwarding a key that Partnero would still have honoured.
@@ -79,12 +84,13 @@ export function saveOriginalUtmParams() {
 export function saveReferralKey() {
   if (typeof window === 'undefined') return;
 
-  const key = new URLSearchParams(window.location.search).get(REFERRAL_PARAM);
-  if (!key) return;
+  const search = new URLSearchParams(window.location.search);
+  const param = REFERRAL_PARAMS.find((name) => search.get(name));
+  if (!param) return;
 
   localStorage.setItem(
     REFERRAL_STORAGE_KEY,
-    JSON.stringify({ key, timestamp: Date.now() })
+    JSON.stringify({ key: search.get(param), param, timestamp: Date.now() })
   );
 }
 
@@ -108,6 +114,18 @@ export function getReferralKey() {
     return data.key || null;
   } catch (e) {
     return null;
+  }
+}
+
+/**
+ * The query param the stored key arrived on, so it is forwarded unchanged
+ */
+function getReferralParam() {
+  try {
+    const stored = JSON.parse(localStorage.getItem(REFERRAL_STORAGE_KEY));
+    return REFERRAL_PARAMS.includes(stored?.param) ? stored.param : REFERRAL_PARAMS[0];
+  } catch (e) {
+    return REFERRAL_PARAMS[0];
   }
 }
 
@@ -181,8 +199,9 @@ export function buildOutboundUrl(urlString) {
     // A `via` already on the link is an explicit choice by whoever authored it
     // and outranks the stored key.
     const referralKey = getReferralKey();
-    if (referralKey && !url.searchParams.has(REFERRAL_PARAM)) {
-      url.searchParams.set(REFERRAL_PARAM, referralKey);
+    const alreadyCarriesReferral = REFERRAL_PARAMS.some((name) => url.searchParams.has(name));
+    if (referralKey && !alreadyCarriesReferral) {
+      url.searchParams.set(getReferralParam(), referralKey);
     }
 
     return url.toString();

--- a/src/utils/utm.test.js
+++ b/src/utils/utm.test.js
@@ -22,6 +22,38 @@ describe('referral (via) preservation', () => {
     visit('');
   });
 
+  it.each(['aff', 'via'])('saves the key from a ?%s= referral link', (param) => {
+    visit(`?${param}=PARTNER123`);
+    saveReferralKey();
+
+    expect(getReferralKey()).toBe('PARTNER123');
+  });
+
+  it('forwards the key under the same param it arrived on', () => {
+    visit('?aff=PARTNER123');
+    saveReferralKey();
+
+    const url = new URL(buildOutboundUrl(SIGNUP));
+    expect(url.searchParams.get('aff')).toBe('PARTNER123');
+    expect(url.searchParams.get('via')).toBeNull();
+  });
+
+  it('prefers aff when a link carries both', () => {
+    visit('?aff=FROM_AFF&via=FROM_VIA');
+    saveReferralKey();
+
+    expect(getReferralKey()).toBe('FROM_AFF');
+  });
+
+  it('does not clobber an explicit aff already on the link', () => {
+    visit('?via=STORED');
+    saveReferralKey();
+
+    const url = new URL(buildOutboundUrl(`${SIGNUP}?aff=EXPLICIT`));
+    expect(url.searchParams.get('aff')).toBe('EXPLICIT');
+    expect(url.searchParams.get('via')).toBeNull();
+  });
+
   it('saves the via key when a visitor lands from a referral link', () => {
     visit('?via=PARTNER123');
     saveReferralKey();


### PR DESCRIPTION
Partnero's referral param is configured per program. Their tracking docs describe `via`, which is what shipped — but the snippet generated for our program emits `aff`.

Reading only one spelling means a dashboard setting we cannot see decides whether every commission is recorded. Both failure directions are silent: the key never lands, and nothing logs. Rather than bet on it, both are accepted.

- `aff` wins when a link carries both, since that is what the program's own snippet writes.
- The key is forwarded to the app under the param it arrived on, so the app sees exactly what Partnero produced.

Companion change in dawarich reads both on the server side.

Stacked on #60 — that hotfix is included here because `package.json` does not parse on main, so nothing builds without it. Merge #60 first and this reduces to the two `utm` files.

## Testing

14 tests in `utm.test.js` including both spellings, precedence, forwarding fidelity and explicit-param override; 198 tests across 22 files pass; `npm run build` succeeds.