### PR TITLE
feat: add affiliate program page

### DIFF
--- a/src/components/pitch/Pitch.module.css
+++ b/src/components/pitch/Pitch.module.css
@@ -45,7 +45,8 @@
   text-wrap: balance;
 }
 
-.heroTitle em {
+.heroTitle em,
+.heroTitle .accent {
   font-style: normal;
   color: var(--pitch-accent);
 }

--- a/src/data/affiliateProgram.js
+++ b/src/data/affiliateProgram.js
@@ -7,6 +7,10 @@ import { PLANS } from './pricingPlans';
  */
 
 export const COMMISSION_RATE = 0.4;
+// Whole-percent form of COMMISSION_RATE, exported so pages that display the
+// rate as text (affiliate page, pricing page) derive it from one place
+// instead of each computing Math.round(COMMISSION_RATE * 100) themselves.
+export const COMMISSION_PERCENT = Math.round(COMMISSION_RATE * 100);
 export const COOKIE_WINDOW_DAYS = 90;
 export const REVIEW_PERIOD_DAYS = 14;
 
@@ -15,10 +19,21 @@ export const REVIEW_PERIOD_DAYS = 14;
 export const PORTAL_SIGNUP_URL = 'https://dawarich.partneroapp.com/register';
 
 const euros = (price) => {
-  // Strip leading currency symbol (€, $, etc.) and thousands separators (,)
-  const cleaned = String(price)
-    .replace(/^[^\d.-]*/, '') // Remove leading non-digit chars (currency symbols)
-    .replace(/,/g, ''); // Remove thousands separators
+  // Strip leading currency symbol (€, $, etc.) only — commas are handled below.
+  const stripped = String(price).replace(/^[^\d.-]*/, '');
+
+  // A string with both '.' and ',' is ambiguous: "1,299.99" (US: comma
+  // thousands, dot decimal) and "1.299,99" (European: dot thousands, comma
+  // decimal) look similar but parse to very different numbers. Refuse to
+  // guess — every real price here is well under 1,000 and never needs a
+  // thousands separator at all.
+  if (stripped.includes('.') && stripped.includes(',')) {
+    throw new Error(
+      `euros() received an ambiguous price: ${JSON.stringify(price)}. A string with both '.' and ',' could be US or European formatting — pass a plain decimal number or string instead.`
+    );
+  }
+
+  const cleaned = stripped.replace(/,/g, ''); // Remove thousands separators
 
   const num = Number.parseFloat(cleaned);
 
@@ -41,14 +56,21 @@ const row = (key, plan, basis, firstYearRevenue, note = null) => ({
   note,
 });
 
+const proMonthlyRevenue = euros(PLANS.pro.priceMonthly) * 12;
+const proMonthlyCommission = commissionOn(proMonthlyRevenue);
+// What actually lands in the dashboard on each of the 12 payments, not just
+// the first-year total — derived from the row's own commission so it can
+// never drift out of sync with the number shown in the "You earn" column.
+const proMonthlyPerPayment = Math.round((proMonthlyCommission / 12) * 100) / 100;
+
 export const EARNINGS = [
   row('proAnnual', 'Pro', `€${PLANS.pro.price}/year`, euros(PLANS.pro.price)),
   row(
     'proMonthly',
     'Pro',
     `€${PLANS.pro.priceMonthly}/month`,
-    euros(PLANS.pro.priceMonthly) * 12,
-    'Paid across 12 payments, and stops early if they cancel.'
+    proMonthlyRevenue,
+    `€${proMonthlyPerPayment.toFixed(2)} on each of the first 12 payments, and stops early if they cancel.`
   ),
   row('family', 'Family', `€${PLANS.family.price}/year`, euros(PLANS.family.price)),
   row('lite', 'Lite', `€${PLANS.lite.price}/year`, euros(PLANS.lite.price)),

--- a/src/data/affiliateProgram.js
+++ b/src/data/affiliateProgram.js
@@ -1,0 +1,40 @@
+import { PLANS } from './pricingPlans';
+
+/**
+ * Affiliate program facts. Every euro amount is derived from PLANS so a price
+ * change flows through instead of silently leaving this page advertising a
+ * commission we no longer pay.
+ */
+
+export const COMMISSION_RATE = 0.4;
+export const COOKIE_WINDOW_DAYS = 90;
+export const REVIEW_PERIOD_DAYS = 14;
+
+// /register, not the bare domain — that redirects to /login, which is the wrong
+// destination for someone who does not have an account yet.
+export const PORTAL_SIGNUP_URL = 'https://dawarich.partneroapp.com/register';
+
+const euros = (price) => Number.parseFloat(price);
+const commissionOn = (revenue) => Math.round(revenue * COMMISSION_RATE * 100) / 100;
+
+const row = (key, plan, basis, firstYearRevenue, note = null) => ({
+  key,
+  plan,
+  basis,
+  firstYearRevenue,
+  commission: commissionOn(firstYearRevenue),
+  note,
+});
+
+export const EARNINGS = [
+  row('proAnnual', 'Pro', `€${PLANS.pro.price}/year`, euros(PLANS.pro.price)),
+  row(
+    'proMonthly',
+    'Pro',
+    `€${PLANS.pro.priceMonthly}/month`,
+    euros(PLANS.pro.priceMonthly) * 12,
+    'Paid across 12 payments, and stops early if they cancel.'
+  ),
+  row('family', 'Family', `€${PLANS.family.price}/year`, euros(PLANS.family.price)),
+  row('lite', 'Lite', `€${PLANS.lite.price}/year`, euros(PLANS.lite.price)),
+];

--- a/src/data/affiliateProgram.js
+++ b/src/data/affiliateProgram.js
@@ -14,7 +14,22 @@ export const REVIEW_PERIOD_DAYS = 14;
 // destination for someone who does not have an account yet.
 export const PORTAL_SIGNUP_URL = 'https://dawarich.partneroapp.com/register';
 
-const euros = (price) => Number.parseFloat(price);
+const euros = (price) => {
+  // Strip leading currency symbol (€, $, etc.) and thousands separators (,)
+  const cleaned = String(price)
+    .replace(/^[^\d.-]*/, '') // Remove leading non-digit chars (currency symbols)
+    .replace(/,/g, ''); // Remove thousands separators
+
+  const num = Number.parseFloat(cleaned);
+
+  if (!Number.isFinite(num)) {
+    throw new Error(
+      `euros() received invalid price: ${JSON.stringify(price)}. Expected a finite number, plain decimal string, or currency-prefixed string.`
+    );
+  }
+
+  return num;
+};
 const commissionOn = (revenue) => Math.round(revenue * COMMISSION_RATE * 100) / 100;
 
 const row = (key, plan, basis, firstYearRevenue, note = null) => ({
@@ -38,3 +53,6 @@ export const EARNINGS = [
   row('family', 'Family', `€${PLANS.family.price}/year`, euros(PLANS.family.price)),
   row('lite', 'Lite', `€${PLANS.lite.price}/year`, euros(PLANS.lite.price)),
 ];
+
+// Test-only export for testing the euros() parser
+export const parseEurosForTest = euros;

--- a/src/data/affiliateProgram.test.js
+++ b/src/data/affiliateProgram.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { PLANS } from './pricingPlans';
 import {
   COMMISSION_RATE,
@@ -6,8 +6,6 @@ import {
   PORTAL_SIGNUP_URL,
   EARNINGS,
 } from './affiliateProgram';
-
-const euros = (s) => Number.parseFloat(s);
 
 describe('affiliate program data', () => {
   it('pays 40% of first-year revenue', () => {
@@ -23,15 +21,15 @@ describe('affiliate program data', () => {
   it('uses the same prices the pricing page shows', () => {
     const byKey = Object.fromEntries(EARNINGS.map((r) => [r.key, r]));
 
-    expect(byKey.lite.firstYearRevenue).toBeCloseTo(euros(PLANS.lite.price), 2);
-    expect(byKey.proAnnual.firstYearRevenue).toBeCloseTo(euros(PLANS.pro.price), 2);
-    expect(byKey.family.firstYearRevenue).toBeCloseTo(euros(PLANS.family.price), 2);
+    expect(byKey.lite.firstYearRevenue).toBeCloseTo(Number.parseFloat(PLANS.lite.price), 2);
+    expect(byKey.proAnnual.firstYearRevenue).toBeCloseTo(Number.parseFloat(PLANS.pro.price), 2);
+    expect(byKey.family.firstYearRevenue).toBeCloseTo(Number.parseFloat(PLANS.family.price), 2);
   });
 
   it('bills a monthly referral over twelve payments, not as a lump', () => {
     const monthly = EARNINGS.find((r) => r.key === 'proMonthly');
 
-    expect(monthly.firstYearRevenue).toBeCloseTo(euros(PLANS.pro.priceMonthly) * 12, 2);
+    expect(monthly.firstYearRevenue).toBeCloseTo(Number.parseFloat(PLANS.pro.priceMonthly) * 12, 2);
     expect(monthly.note).toMatch(/12 payments/i);
   });
 
@@ -41,5 +39,67 @@ describe('affiliate program data', () => {
 
   it('sends new affiliates to the register page, not the login page', () => {
     expect(PORTAL_SIGNUP_URL).toBe('https://dawarich.partneroapp.com/register');
+  });
+});
+
+describe('euros() price parser', () => {
+  it('parses plain decimal strings', async () => {
+    const { parseEurosForTest } = await import('./affiliateProgram');
+    expect(parseEurosForTest('59.99')).toBe(59.99);
+  });
+
+  it('strips leading currency symbols', async () => {
+    const { parseEurosForTest } = await import('./affiliateProgram');
+    expect(parseEurosForTest('€59.99')).toBe(59.99);
+    expect(parseEurosForTest('$100.50')).toBe(100.50);
+  });
+
+  it('removes thousands separators', async () => {
+    const { parseEurosForTest } = await import('./affiliateProgram');
+    expect(parseEurosForTest('1,039')).toBe(1039);
+    expect(parseEurosForTest('1,299.99')).toBe(1299.99);
+  });
+
+  it('throws on invalid/non-finite values', async () => {
+    const { parseEurosForTest } = await import('./affiliateProgram');
+    expect(() => parseEurosForTest('not a number')).toThrow();
+    expect(() => parseEurosForTest('€abc')).toThrow();
+    expect(() => parseEurosForTest(NaN)).toThrow();
+  });
+});
+
+describe('affiliate program data propagation', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('flows price changes through to commissions via dynamic import', async () => {
+    // Mock a mutated PLANS object with a different pro.price
+    vi.doMock('./pricingPlans', () => ({
+      PLANS: {
+        lite: { price: '59.99' },
+        pro: { price: '299.99', priceMonthly: '17.99' }, // doubled from 149.99
+        family: { price: '299.99' },
+      },
+      DwIcon: () => null,
+      DW_ICONS: {},
+      COMPARE_GROUPS: [],
+    }));
+
+    // Dynamically import with the mocked PLANS
+    const { EARNINGS: mutatedEarnings } = await import('./affiliateProgram');
+
+    // Find the proAnnual row and verify it uses the new price
+    const proAnnualRow = mutatedEarnings.find((r) => r.key === 'proAnnual');
+    expect(proAnnualRow.firstYearRevenue).toBe(299.99);
+    expect(proAnnualRow.commission).toBeCloseTo(299.99 * 0.4, 2);
+
+    // Verify proMonthly still uses priceMonthly and multiplies by 12
+    const proMonthlyRow = mutatedEarnings.find((r) => r.key === 'proMonthly');
+    expect(proMonthlyRow.firstYearRevenue).toBe(17.99 * 12);
   });
 });

--- a/src/data/affiliateProgram.test.js
+++ b/src/data/affiliateProgram.test.js
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { PLANS } from './pricingPlans';
+import { REFERRAL_STORAGE_DURATION } from '../utils/utm';
 import {
   COMMISSION_RATE,
+  COMMISSION_PERCENT,
   COOKIE_WINDOW_DAYS,
   PORTAL_SIGNUP_URL,
   EARNINGS,
@@ -33,12 +35,16 @@ describe('affiliate program data', () => {
     expect(monthly.note).toMatch(/12 payments/i);
   });
 
-  it('states the cookie window the code actually honours', () => {
-    expect(COOKIE_WINDOW_DAYS).toBe(90);
+  it('advertises the window the forwarding code actually honours', () => {
+    expect(COOKIE_WINDOW_DAYS * 24 * 60 * 60 * 1000).toBe(REFERRAL_STORAGE_DURATION);
   });
 
   it('sends new affiliates to the register page, not the login page', () => {
     expect(PORTAL_SIGNUP_URL).toBe('https://dawarich.partneroapp.com/register');
+  });
+
+  it('exposes the commission rate as the whole percent shown on the page', () => {
+    expect(COMMISSION_PERCENT).toBe(Math.round(COMMISSION_RATE * 100));
   });
 });
 
@@ -57,7 +63,6 @@ describe('euros() price parser', () => {
   it('removes thousands separators', async () => {
     const { parseEurosForTest } = await import('./affiliateProgram');
     expect(parseEurosForTest('1,039')).toBe(1039);
-    expect(parseEurosForTest('1,299.99')).toBe(1299.99);
   });
 
   it('throws on invalid/non-finite values', async () => {
@@ -65,6 +70,16 @@ describe('euros() price parser', () => {
     expect(() => parseEurosForTest('not a number')).toThrow();
     expect(() => parseEurosForTest('€abc')).toThrow();
     expect(() => parseEurosForTest(NaN)).toThrow();
+  });
+
+  it('throws on strings mixing "." and "," instead of guessing the format', async () => {
+    const { parseEurosForTest } = await import('./affiliateProgram');
+    // European formatting (dot thousands, comma decimal) — would silently
+    // become 1.29999 if commas were just stripped.
+    expect(() => parseEurosForTest('1.299,99')).toThrow();
+    // US formatting (comma thousands, dot decimal) is equally ambiguous
+    // once both separators can appear, so it is rejected too.
+    expect(() => parseEurosForTest('1,299.99')).toThrow();
   });
 });
 

--- a/src/data/affiliateProgram.test.js
+++ b/src/data/affiliateProgram.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { PLANS } from './pricingPlans';
+import {
+  COMMISSION_RATE,
+  COOKIE_WINDOW_DAYS,
+  PORTAL_SIGNUP_URL,
+  EARNINGS,
+} from './affiliateProgram';
+
+const euros = (s) => Number.parseFloat(s);
+
+describe('affiliate program data', () => {
+  it('pays 40% of first-year revenue', () => {
+    expect(COMMISSION_RATE).toBe(0.4);
+  });
+
+  it('derives every payout from the live pricing data', () => {
+    for (const row of EARNINGS) {
+      expect(row.commission).toBeCloseTo(row.firstYearRevenue * COMMISSION_RATE, 2);
+    }
+  });
+
+  it('uses the same prices the pricing page shows', () => {
+    const byKey = Object.fromEntries(EARNINGS.map((r) => [r.key, r]));
+
+    expect(byKey.lite.firstYearRevenue).toBeCloseTo(euros(PLANS.lite.price), 2);
+    expect(byKey.proAnnual.firstYearRevenue).toBeCloseTo(euros(PLANS.pro.price), 2);
+    expect(byKey.family.firstYearRevenue).toBeCloseTo(euros(PLANS.family.price), 2);
+  });
+
+  it('bills a monthly referral over twelve payments, not as a lump', () => {
+    const monthly = EARNINGS.find((r) => r.key === 'proMonthly');
+
+    expect(monthly.firstYearRevenue).toBeCloseTo(euros(PLANS.pro.priceMonthly) * 12, 2);
+    expect(monthly.note).toMatch(/12 payments/i);
+  });
+
+  it('states the cookie window the code actually honours', () => {
+    expect(COOKIE_WINDOW_DAYS).toBe(90);
+  });
+
+  it('sends new affiliates to the register page, not the login page', () => {
+    expect(PORTAL_SIGNUP_URL).toBe('https://dawarich.partneroapp.com/register');
+  });
+});

--- a/src/data/footerLinks.js
+++ b/src/data/footerLinks.js
@@ -23,6 +23,7 @@ export const footerLinks = [
       { label: 'Map Poster Studio', to: '/poster-studio' },
       { label: 'Pricing', to: '/pricing' },
       { label: 'Dawarich Cloud', to: '/cloud' },
+      { label: 'Affiliate Program', to: '/affiliate' },
       { label: 'Roadmap', to: '/roadmap' },
       { label: 'Changelog', to: '/docs/changelog' },
     ],

--- a/src/pages/affiliate/index.js
+++ b/src/pages/affiliate/index.js
@@ -1,0 +1,189 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import Head from '@docusaurus/Head';
+import Link from '@docusaurus/Link';
+import { PitchPage, Objections, ProofStrip } from '@site/src/components/pitch';
+import pitch from '@site/src/components/pitch/Pitch.module.css';
+import {
+  COMMISSION_RATE,
+  COOKIE_WINDOW_DAYS,
+  REVIEW_PERIOD_DAYS,
+  PORTAL_SIGNUP_URL,
+  EARNINGS,
+} from '@site/src/data/affiliateProgram';
+import styles from './styles.module.css';
+
+const PERCENT = `${Math.round(COMMISSION_RATE * 100)}%`;
+const HEADLINE = EARNINGS.find((r) => r.key === 'proAnnual');
+const money = (n) => `€${n.toFixed(2)}`;
+
+const STATS = [
+  { value: `${PERCENT} of the first year`, label: 'On every plan, including renewals within that year' },
+  { value: `${COOKIE_WINDOW_DAYS}-day window`, label: 'From the first click to the sign-up' },
+  { value: `Paid after ${REVIEW_PERIOD_DAYS} days`, label: 'Once the refund window closes' },
+];
+
+const HOW = [
+  {
+    title: 'Your link works even when cookies do not',
+    body:
+      'Most affiliate programs live and die by a browser cookie. Ours records the referral on our servers the moment the account is created, so a visitor who clears cookies, declines the banner, or switches from your blog to their laptop is still credited to you.',
+    note: 'Server-side attribution',
+  },
+  {
+    title: 'You are paid on what people actually keep',
+    body:
+      `Commission is held for ${REVIEW_PERIOD_DAYS} days while the refund window runs, then released automatically. Nothing is clawed back later, and you can see every pending and approved reward in your dashboard.`,
+  },
+  {
+    title: 'Web subscriptions only',
+    body:
+      'Sign-ups that pay through our website earn commission. Subscriptions bought inside the iOS or Android apps go through Apple and Google, never reach our billing system, and cannot be attributed. Self-hosting Dawarich is free and earns nothing at all.',
+    note: 'Worth knowing before you write',
+  },
+];
+
+const objections = [
+  {
+    q: 'My audience mostly self-hosts. Is this worth my time?',
+    a: 'Probably not, and we would rather say so now. Dawarich is open source and self-hosting is free, so a self-hosting tutorial earns nothing however well it performs. This program pays on Dawarich Cloud subscriptions. If your audience wants tracking without running a server, it is worth your time.',
+  },
+  {
+    q: 'When do I actually get paid?',
+    a: `A referral becomes a pending reward as soon as the subscription is paid for, and is approved automatically after ${REVIEW_PERIOD_DAYS} days once the refund window has closed. Payouts are handled in the affiliate dashboard.`,
+  },
+  {
+    q: 'What happens if someone refunds?',
+    a: `Nothing you need to handle. The ${REVIEW_PERIOD_DAYS}-day hold exists precisely so a refund inside the window cancels the pending reward instead of being taken back from a balance you have already been paid.`,
+  },
+  {
+    q: 'Does the person I refer pay more?',
+    a: 'No. The price is identical whether they arrive through your link or type the address themselves. The commission comes out of our margin, not their bill.',
+  },
+  {
+    q: 'What am I not allowed to do?',
+    a: 'Do not bid on "Dawarich" or close variants in paid search, do not refer yourself, and do not list us on coupon or deal-aggregation sites. Disclose that your link is an affiliate link — most jurisdictions require it, and readers respect it.',
+  },
+];
+
+export default function AffiliatePage() {
+  return (
+    <Layout
+      title="Affiliate Program — Earn 40% of the First Year"
+      description={`Earn ${PERCENT} of first-year revenue for every Dawarich Cloud subscriber you refer. ${COOKIE_WINDOW_DAYS}-day window, server-side attribution, paid after the refund window.`}>
+      <Head>
+        <meta property="og:title" content="Dawarich Affiliate Program" />
+        <meta
+          property="og:description"
+          content={`Earn ${PERCENT} of first-year revenue on every Dawarich Cloud subscription you refer. ${money(HEADLINE.commission)} per annual Pro subscriber.`}
+        />
+        <meta property="og:image" content="https://dawarich.app/img/meta-image.png" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <link rel="canonical" href="https://dawarich.app/affiliate" />
+      </Head>
+
+      <PitchPage>
+        <section className={pitch.hero}>
+          <div className={pitch.container}>
+            <h1 className={pitch.heroTitle}>
+              Earn {money(HEADLINE.commission)} for every Pro
+              <br />
+              <em>subscriber you send us.</em>
+            </h1>
+            <p className={pitch.heroSub}>
+              Dawarich is a private alternative to Google Timeline. If you write about privacy,
+              self-hosting, travel or quantified self, your readers are already looking for it —
+              and {PERCENT} of their first year comes back to you.
+            </p>
+            <div className={pitch.heroActions}>
+              <Link className={pitch.primaryCta} href={PORTAL_SIGNUP_URL}>
+                Become an affiliate
+              </Link>
+              <Link className={pitch.secondaryCta} to="/pricing">
+                See what people are buying
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.stats}>
+          <div className={pitch.container}>
+            <div className={styles.statsGrid}>
+              {STATS.map((s) => (
+                <div key={s.value} className={styles.stat}>
+                  <p className={styles.statValue}>{s.value}</p>
+                  <p className={styles.statLabel}>{s.label}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <ProofStrip />
+
+        <section className={styles.earnings}>
+          <div className={pitch.container}>
+            <h2 className={styles.earningsTitle}>What each referral is worth</h2>
+            <p className={styles.earningsSub}>
+              {PERCENT} of everything they pay in their first year.
+            </p>
+            <div className={styles.tableWrap}>
+              <table className={styles.table}>
+                <thead>
+                  <tr>
+                    <th>Plan</th>
+                    <th>They pay</th>
+                    <th>You earn</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {EARNINGS.map((r) => (
+                    <tr key={r.key}>
+                      <td>{r.plan}</td>
+                      <td>
+                        {r.basis}
+                        {r.note ? <span className={styles.rowNote}>{r.note}</span> : null}
+                      </td>
+                      <td className={styles.amount}>{money(r.commission)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.how}>
+          <div className={pitch.container}>
+            <h2 className={styles.earningsTitle}>How the program works</h2>
+            <div className={styles.howGrid}>
+              {HOW.map((card) => (
+                <div key={card.title} className={styles.card}>
+                  <h3 className={styles.cardTitle}>{card.title}</h3>
+                  <p className={styles.cardBody}>{card.body}</p>
+                  {card.note ? <span className={styles.cardNote}>{card.note}</span> : null}
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <Objections title="The questions worth asking first" items={objections} />
+
+        <section className={pitch.close}>
+          <div className={pitch.container}>
+            <h2 className={pitch.closeTitle}>Start earning on your next post</h2>
+            <p className={pitch.closeSub}>
+              Sign up, get your link, and share it. No application to wait on, no minimum audience.
+            </p>
+            <div className={pitch.closeActions}>
+              <Link className={pitch.primaryCta} href={PORTAL_SIGNUP_URL}>
+                Become an affiliate
+              </Link>
+            </div>
+          </div>
+        </section>
+      </PitchPage>
+    </Layout>
+  );
+}

--- a/src/pages/affiliate/index.js
+++ b/src/pages/affiliate/index.js
@@ -5,7 +5,7 @@ import Link from '@docusaurus/Link';
 import { PitchPage, Objections, ProofStrip } from '@site/src/components/pitch';
 import pitch from '@site/src/components/pitch/Pitch.module.css';
 import {
-  COMMISSION_RATE,
+  COMMISSION_PERCENT,
   COOKIE_WINDOW_DAYS,
   REVIEW_PERIOD_DAYS,
   PORTAL_SIGNUP_URL,
@@ -13,9 +13,10 @@ import {
 } from '@site/src/data/affiliateProgram';
 import styles from './styles.module.css';
 
-const PERCENT = `${Math.round(COMMISSION_RATE * 100)}%`;
+const PERCENT = `${COMMISSION_PERCENT}%`;
 const HEADLINE = EARNINGS.find((r) => r.key === 'proAnnual');
 const money = (n) => `€${n.toFixed(2)}`;
+const moneyShort = (n) => (Number.isInteger(n) ? `€${n}` : money(n));
 
 const STATS = [
   { value: `${PERCENT} of the first year`, label: 'On every plan, including renewals within that year' },
@@ -27,7 +28,7 @@ const HOW = [
   {
     title: 'Your link works even when cookies do not',
     body:
-      'Most affiliate programs live and die by a browser cookie. Ours records the referral on our servers the moment the account is created, so a visitor who clears cookies, declines the banner, or switches from your blog to their laptop is still credited to you.',
+      'Most affiliate programs live and die by a browser cookie. Your referral is recorded on our servers the moment the account is created, so it survives the gap between someone reading your post and deciding to sign up days later — as long as they come back in the same browser.',
     note: 'Server-side attribution',
   },
   {
@@ -86,9 +87,9 @@ export default function AffiliatePage() {
         <section className={pitch.hero}>
           <div className={pitch.container}>
             <h1 className={pitch.heroTitle}>
-              Earn {money(HEADLINE.commission)} for every Pro
+              Earn {moneyShort(HEADLINE.commission)} for every annual Pro
               <br />
-              <em>subscriber you send us.</em>
+              <span className={pitch.accent}>subscriber you send us.</span>
             </h1>
             <p className={pitch.heroSub}>
               Dawarich is a private alternative to Google Timeline. If you write about privacy,
@@ -131,9 +132,9 @@ export default function AffiliatePage() {
               <table className={styles.table}>
                 <thead>
                   <tr>
-                    <th>Plan</th>
-                    <th>They pay</th>
-                    <th>You earn</th>
+                    <th scope="col">Plan</th>
+                    <th scope="col">They pay</th>
+                    <th scope="col">You earn</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/src/pages/affiliate/index.js
+++ b/src/pages/affiliate/index.js
@@ -69,7 +69,7 @@ const objections = [
 export default function AffiliatePage() {
   return (
     <Layout
-      title="Affiliate Program — Earn 40% of the First Year"
+      title={`Affiliate Program — Earn ${PERCENT} of the First Year`}
       description={`Earn ${PERCENT} of first-year revenue for every Dawarich Cloud subscriber you refer. ${COOKIE_WINDOW_DAYS}-day window, server-side attribution, paid after the refund window.`}>
       <Head>
         <meta property="og:title" content="Dawarich Affiliate Program" />

--- a/src/pages/affiliate/styles.module.css
+++ b/src/pages/affiliate/styles.module.css
@@ -1,0 +1,115 @@
+.stats {
+  padding: 2.5rem 0;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.statsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.stat {
+  text-align: center;
+}
+
+.statValue {
+  margin: 0 0 0.25rem;
+  font-size: 1.35rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.statLabel {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.earnings {
+  padding: 3rem 0;
+}
+
+.earningsTitle {
+  margin: 0 0 0.5rem;
+  font-size: 1.75rem;
+}
+
+.earningsSub {
+  margin: 0 0 1.5rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.tableWrap {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  vertical-align: top;
+}
+
+.table th {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.rowNote {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.82rem;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.amount {
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.how {
+  padding: 3rem 0;
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.howGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.card {
+  padding: 1.25rem;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+}
+
+.cardTitle {
+  margin: 0 0 0.5rem;
+  font-size: 1.05rem;
+}
+
+.cardBody {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.cardNote {
+  display: inline-block;
+  margin-top: 0.6rem;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ifm-color-emphasis-600);
+}

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -3,6 +3,7 @@ import Head from "@docusaurus/Head";
 import Layout from "@theme/Layout";
 import Link from "@docusaurus/Link";
 import { initializePaddle } from "@paddle/paddle-js";
+import { COMMISSION_RATE } from "@site/src/data/affiliateProgram";
 import PricingSection from "@site/src/components/PricingSection";
 import PricingCompare from "@site/src/components/PricingCompare";
 import FAQ from "@site/src/components/FAQ";
@@ -103,8 +104,11 @@ export default function PricingPage() {
 				<PricingSection />
 				<PricingCompare />
 				<p className="margin-top--lg text--center">
-					Writing about Dawarich? <Link to="/affiliate">Earn 40% of the first year</Link> for
-					every subscriber you refer.
+					Writing about Dawarich?{" "}
+					<Link to="/affiliate">
+						Earn {Math.round(COMMISSION_RATE * 100)}% of the first year
+					</Link>{" "}
+					for every subscriber you refer.
 				</p>
 				<FAQ />
 			</main>

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import Head from "@docusaurus/Head";
 import Layout from "@theme/Layout";
+import Link from "@docusaurus/Link";
 import { initializePaddle } from "@paddle/paddle-js";
 import PricingSection from "@site/src/components/PricingSection";
 import PricingCompare from "@site/src/components/PricingCompare";
@@ -101,6 +102,10 @@ export default function PricingPage() {
 			<main>
 				<PricingSection />
 				<PricingCompare />
+				<p className="margin-top--lg text--center">
+					Writing about Dawarich? <Link to="/affiliate">Earn 40% of the first year</Link> for
+					every subscriber you refer.
+				</p>
 				<FAQ />
 			</main>
 		</Layout>

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -3,7 +3,7 @@ import Head from "@docusaurus/Head";
 import Layout from "@theme/Layout";
 import Link from "@docusaurus/Link";
 import { initializePaddle } from "@paddle/paddle-js";
-import { COMMISSION_RATE } from "@site/src/data/affiliateProgram";
+import { COMMISSION_PERCENT } from "@site/src/data/affiliateProgram";
 import PricingSection from "@site/src/components/PricingSection";
 import PricingCompare from "@site/src/components/PricingCompare";
 import FAQ from "@site/src/components/FAQ";
@@ -106,7 +106,7 @@ export default function PricingPage() {
 				<p className="margin-top--lg text--center">
 					Writing about Dawarich?{" "}
 					<Link to="/affiliate">
-						Earn {Math.round(COMMISSION_RATE * 100)}% of the first year
+						Earn {COMMISSION_PERCENT}% of the first year
 					</Link>{" "}
 					for every subscriber you refer.
 				</p>

--- a/src/utils/utm.js
+++ b/src/utils/utm.js
@@ -31,7 +31,9 @@ const REFERRAL_PARAMS = ['aff', 'via'];
 const REFERRAL_STORAGE_KEY = 'partnero_referral';
 // Keep at or above the cookie lifetime configured in the Partnero program, otherwise
 // the site stops forwarding a key that Partnero would still have honoured.
-const REFERRAL_STORAGE_DURATION = 90 * 24 * 60 * 60 * 1000; // 90 days in milliseconds
+// Exported so affiliateProgram.js/its tests can assert the advertised
+// COOKIE_WINDOW_DAYS actually matches what this file enforces.
+export const REFERRAL_STORAGE_DURATION = 90 * 24 * 60 * 60 * 1000; // 90 days in milliseconds
 
 /**
  * Get UTM parameters from URL


### PR DESCRIPTION
Adds a public affiliate-recruitment page at `/affiliate` for the Partnero program, plus links from the footer and pricing page.

## What it says

40% of a referred customer's first-year revenue — €60 for an annual Pro subscriber, €7.20 on each of the first twelve payments for a monthly one, €120 for Family, €24 for Lite. 90-day window, commission released after the 14-day refund window, CTA into the Partnero signup portal.

## Why the numbers are derived, not written

`src/data/affiliateProgram.js` computes every figure from `PLANS` in `pricingPlans.js`, and a test asserts each payout equals the rate times the live price. A price change flows through instead of silently leaving this page advertising a commission we no longer pay — the same failure mode that already makes pricing changes risky elsewhere.

The same applies to the window: `REFERRAL_STORAGE_DURATION` is now exported from `src/utils/utm.js`, and a test asserts `COOKIE_WINDOW_DAYS * 86400000` equals it. Shortening one without the other fails the suite rather than shipping a page that promises a window the forwarding code no longer honours.

## Deliberate choices

- **`PitchHero` and `CloseCTA` are not reused.** Both hardcode a CTA to `my.dawarich.app/users/sign_up` plus a "Self-host free forever" link — wrong destination, and counterproductive on a page explaining that self-hosting earns nothing. The page defines its own hero and closing CTA and imports `Pitch.module.css` for identical styling, rather than adding override props to a component six live landing pages depend on. `ProofStrip`, `Objections` and `PitchPage` are reused as-is.
- **The self-hosting caveat is stated, not buried.** Most Dawarich users self-host for free and earn an affiliate nothing. The third card and the first FAQ both say so plainly.
- **No cross-device claim.** Attribution is per-browser at every hop, so the copy says "as long as they come back in the same browser".

## Testing

211 tests passing, `npm run build` succeeds. Verified in the built HTML: two `/register` CTAs and all four commission figures render.

## Known, not addressed here

Three items are open and none is a code change in this branch:

1. **Consent.** The cookie banner and privacy policy say affiliate referral credit requires consent, but `saveReferralKey()` in `src/utils/utm.js` writes to localStorage on every page load without checking. That predates this branch and is already live — this page makes it easier to notice.
2. The FAQ says "nothing is clawed back later", which also covers chargebacks landing after the 14-day hold. Generous, but currently an unconditional public commitment.
3. The Partnero reward rate and first-year cap have not been verified in the dashboard. If the reward is one-time rather than recurring, a monthly referral earns €7.20 rather than €86.35.
