### PR TITLE
feat: Route Video Maker — GPX & Google Timeline to animated MP4, fully in-browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "jszip": "^3.10.1",
         "leaflet": "^1.9.4",
         "maplibre-gl": "^5.16.0",
+        "mp4-muxer": "^5.2.2",
         "postcss-selector-parser": "^7.0.0",
         "prism-react-renderer": "^2.4.1",
         "react": "^18.0.0",
@@ -6959,6 +6960,12 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/dom-webcodecs": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.19.tgz",
+      "integrity": "sha512-+yFUIDUaASFz0vQpWBErPxun/Lb+F0TdrlTsj50gm7K797YzEx2TmV6fEiwciHyFNghlZYPgQXH5qRcwMHcJFQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -7319,6 +7326,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/wicg-file-system-access": {
+      "version": "2020.9.8",
+      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.8.tgz",
+      "integrity": "sha512-ggMz8nOygG7d/stpH40WVaNvBwuyYLnrg5Mbyf6bmsj/8+gb6Ei4ZZ9/4PNpcPNTT8th9Q8sM8wYmWGjMWLX/A==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -16301,6 +16314,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mp4-muxer": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/mp4-muxer/-/mp4-muxer-5.2.2.tgz",
+      "integrity": "sha512-dhozjTywI0h2qFzeShagt8YYw811fh1XlwiDCE2f6Aeqf6xG2CyuShoSa5E0AZDO8pPF0JOZ3wOmWBNWIGdSpQ==",
+      "deprecated": "This library is superseded by Mediabunny. Please migrate to it.",
+      "license": "MIT",
+      "dependencies": {
+        "@types/dom-webcodecs": "^0.1.6",
+        "@types/wicg-file-system-access": "^2020.9.5"
       }
     },
     "node_modules/mrmime": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "jszip": "^3.10.1",
     "leaflet": "^1.9.4",
     "maplibre-gl": "^5.16.0",
+    "mp4-muxer": "^5.2.2",
     "postcss-selector-parser": "^7.0.0",
     "prism-react-renderer": "^2.4.1",
     "react": "^18.0.0",

--- a/src/components/VideoStudio/VideoControls.js
+++ b/src/components/VideoStudio/VideoControls.js
@@ -1,0 +1,180 @@
+import React from 'react';
+import { DAWARICH_BLUE } from '../../utils/videoExport/colorUtil';
+import styles from './VideoStudio.module.css';
+import { MAX_DURATION_SEC, MIN_DURATION_SEC, VIDEO_FORMATS } from './useVideoStudio';
+
+function prettyThemeName(key) {
+  return key.replaceAll('_', ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function Segmented({ label, options, value, onChange, testPrefix }) {
+  return (
+    <div className={styles.controlRow}>
+      <span className={styles.controlLabel}>{label}</span>
+      <div className={styles.segmented} role="radiogroup" aria-label={label}>
+        {options.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={value === option.value}
+            className={`${styles.segment} ${value === option.value ? styles.segmentActive : ''}`}
+            onClick={() => onChange(option.value)}
+            data-testid={`${testPrefix}-${option.value}`}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function VideoControls({ studio, disabled }) {
+  const {
+    themeKey,
+    setThemeKey,
+    themeKeys,
+    theme,
+    formatKey,
+    setFormatKey,
+    durationSec,
+    setDurationSec,
+    cameraMode,
+    setCameraMode,
+    followZoom,
+    setFollowZoom,
+    trackColor,
+    setTrackColor,
+    trackWidth,
+    setTrackWidth,
+    units,
+    setUnits,
+  } = studio;
+
+  return (
+    <fieldset className={styles.controls} disabled={disabled}>
+      <div className={styles.group} role="group" aria-label="Map style">
+        <span className={styles.groupLegend}>Map style</span>
+        <div className={styles.themeGrid}>
+          {themeKeys.map((key) => (
+            <button
+              key={key}
+              type="button"
+              className={`${styles.themeChip} ${themeKey === key ? styles.themeChipSelected : ''}`}
+              style={{ backgroundImage: `url(/img/poster_themes/${key}.webp)` }}
+              aria-label={`${prettyThemeName(key)} theme`}
+              aria-pressed={themeKey === key}
+              title={prettyThemeName(key)}
+              onClick={() => setThemeKey(key)}
+              data-testid={`video-theme-${key}`}
+            />
+          ))}
+        </div>
+        <div className={styles.controlRow}>
+          <span className={styles.controlLabel}>Route color</span>
+          <div className={styles.colorRow}>
+            <input
+              type="color"
+              aria-label="Route color"
+              value={trackColor ?? theme?.route ?? DAWARICH_BLUE}
+              onChange={(event) => setTrackColor(event.target.value)}
+              data-testid="video-color"
+            />
+            {trackColor && (
+              <button
+                type="button"
+                className={styles.linkButton}
+                onClick={() => setTrackColor(null)}
+              >
+                Theme default
+              </button>
+            )}
+          </div>
+        </div>
+        <label className={styles.controlRow}>
+          <span className={styles.controlLabel}>
+            Line width <span className={styles.controlValue}>{trackWidth.toFixed(1)}×</span>
+          </span>
+          <input
+            type="range"
+            min={0.6}
+            max={2.4}
+            step={0.2}
+            value={trackWidth}
+            onChange={(event) => setTrackWidth(Number(event.target.value))}
+            data-testid="video-width"
+          />
+        </label>
+      </div>
+
+      <div className={styles.group} role="group" aria-label="Video">
+        <span className={styles.groupLegend}>Video</span>
+        <Segmented
+          label="Format"
+          testPrefix="video-format"
+          value={formatKey}
+          onChange={setFormatKey}
+          options={Object.entries(VIDEO_FORMATS).map(([value, format]) => ({
+            value,
+            label: format.label,
+          }))}
+        />
+        <label className={styles.controlRow}>
+          <span className={styles.controlLabel}>
+            Length <span className={styles.controlValue}>{durationSec} s</span>
+          </span>
+          <input
+            type="range"
+            min={MIN_DURATION_SEC}
+            max={MAX_DURATION_SEC}
+            step={1}
+            value={durationSec}
+            onChange={(event) => setDurationSec(Number(event.target.value))}
+            data-testid="video-duration"
+          />
+        </label>
+        <Segmented
+          label="Camera"
+          testPrefix="video-camera"
+          value={cameraMode}
+          onChange={setCameraMode}
+          options={[
+            { value: 'overview', label: 'Whole route' },
+            { value: 'follow', label: 'Follow the pen' },
+          ]}
+        />
+        {cameraMode === 'follow' && (
+          <label className={styles.controlRow}>
+            <span className={styles.controlLabel}>
+              Follow zoom <span className={styles.controlValue}>{followZoom.toFixed(1)}</span>
+            </span>
+            <input
+              type="range"
+              min={11}
+              max={15}
+              step={0.5}
+              value={followZoom}
+              onChange={(event) => setFollowZoom(Number(event.target.value))}
+              data-testid="video-follow-zoom"
+            />
+          </label>
+        )}
+      </div>
+
+      <div className={styles.group} role="group" aria-label="Output">
+        <span className={styles.groupLegend}>Output</span>
+        <Segmented
+          label="Units"
+          testPrefix="video-units"
+          value={units}
+          onChange={setUnits}
+          options={[
+            { value: 'km', label: 'Kilometers' },
+            { value: 'mi', label: 'Miles' },
+          ]}
+        />
+      </div>
+    </fieldset>
+  );
+}

--- a/src/components/VideoStudio/VideoPreviewMap.js
+++ b/src/components/VideoStudio/VideoPreviewMap.js
@@ -1,0 +1,111 @@
+// The studio stage: a framed live map in the output aspect ratio. The full
+// route is shown for framing; the animation only exists in the rendered file,
+// which overlays the same frame when a render finishes.
+import React, { Fragment, useEffect, useRef } from 'react';
+import { createPreviewMap, trackBounds } from '../../lib/poster-studio/ui/preview';
+import styles from './VideoStudio.module.css';
+
+const RESTYLE_DEBOUNCE_MS = 150;
+
+const FRAME_CLASS_BY_FORMAT = {
+  portrait: 'framePortrait',
+  landscape: 'frameLandscape',
+  square: 'frameSquare',
+};
+
+export default function VideoPreviewMap({
+  style,
+  trackGeojson,
+  fallbackBounds,
+  formatKey,
+  resultUrl,
+  statRows,
+}) {
+  const frameRef = useRef(null);
+  const mapContainerRef = useRef(null);
+  const mapRef = useRef(null);
+
+  useEffect(() => {
+    const map = createPreviewMap({
+      container: mapContainerRef.current,
+      style,
+      bounds: trackBounds(trackGeojson) ?? fallbackBounds,
+    });
+    mapRef.current = map;
+
+    const observer = new ResizeObserver(() => map.resize());
+    observer.observe(frameRef.current);
+
+    return () => {
+      observer.disconnect();
+      map.remove();
+      mapRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const styleApplied = useRef(false);
+  useEffect(() => {
+    if (!styleApplied.current) {
+      styleApplied.current = true;
+      return undefined;
+    }
+    const timer = setTimeout(() => mapRef.current?.setStyle(style), RESTYLE_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [style]);
+
+  const recenter = () => {
+    const bounds = trackBounds(trackGeojson) ?? fallbackBounds;
+    if (bounds) mapRef.current?.fitBounds(bounds, { padding: 24 });
+  };
+
+  return (
+    <Fragment>
+      <div
+        className={`${styles.frame} ${styles[FRAME_CLASS_BY_FORMAT[formatKey]]}`}
+        ref={frameRef}
+        data-testid="video-frame"
+      >
+        <div className={styles.mapContainer} ref={mapContainerRef} data-testid="video-map" />
+        {resultUrl ? (
+          /* eslint-disable-next-line jsx-a11y/media-has-caption */
+          <video
+            className={styles.resultVideo}
+            src={resultUrl}
+            controls
+            autoPlay
+            muted
+            loop
+            playsInline
+            data-testid="video-result"
+          />
+        ) : (
+          <button
+            type="button"
+            className={styles.recenterButton}
+            onClick={recenter}
+            data-testid="video-recenter"
+          >
+            Recenter
+          </button>
+        )}
+      </div>
+      {statRows?.length > 0 && (
+        <p className={styles.stageCaption} data-testid="video-stats">
+          {statRows.map(([label, value], index) => (
+            <Fragment key={label}>
+              {index > 0 && (
+                <span className={styles.captionDivider} aria-hidden="true">
+                  ·
+                </span>
+              )}
+              <span aria-label={`${label}: ${value}`}>
+                <strong>{value}</strong>
+              </span>
+            </Fragment>
+          ))}
+        </p>
+      )}
+    </Fragment>
+  );
+}

--- a/src/components/VideoStudio/VideoStudio.module.css
+++ b/src/components/VideoStudio/VideoStudio.module.css
@@ -1,0 +1,470 @@
+/* The studio is a deliberately dark, self-contained editor surface — video
+   tools are judged against dark chrome, and the map themes are built for it.
+   Its palette is scoped here and does not follow the site theme. */
+
+.studio {
+  --st-bg: #101318;
+  --st-panel: #171b22;
+  --st-inset: #0b0d11;
+  --st-border: rgba(236, 238, 242, 0.09);
+  --st-text: #eceef2;
+  --st-muted: rgba(236, 238, 242, 0.6);
+  --st-accent: #3d7ff2;
+  --st-accent-strong: #2f6ede;
+  --st-danger: #ff6b60;
+
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-areas:
+    'stage'
+    'rail'
+    'bar';
+  overflow: hidden;
+  border: 1px solid var(--st-border);
+  border-radius: 18px;
+  background: var(--st-bg);
+  color: var(--st-text);
+  box-shadow: 0 24px 48px -24px rgba(8, 10, 14, 0.5), 0 2px 8px rgba(8, 10, 14, 0.18);
+}
+
+@media (min-width: 997px) {
+  .studio {
+    grid-template-columns: minmax(0, 1fr) 312px;
+    grid-template-areas:
+      'stage rail'
+      'bar bar';
+  }
+}
+
+/* ---------- Stage ---------- */
+
+.stage {
+  grid-area: stage;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.8rem;
+  min-width: 0;
+  padding: 1.25rem 1rem 1.5rem;
+  background:
+    radial-gradient(120% 90% at 50% 0%, rgba(61, 127, 242, 0.07), transparent 60%),
+    var(--st-inset);
+}
+
+@media (min-width: 997px) {
+  .stage {
+    padding: 2.25rem 2rem;
+  }
+}
+
+.frame {
+  position: relative;
+  max-width: 100%;
+  overflow: hidden;
+  border: 1px solid var(--st-border);
+  border-radius: 14px;
+  background: #000;
+  box-shadow: 0 16px 40px -16px rgba(0, 0, 0, 0.65), 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+
+.framePortrait {
+  height: min(68vh, 680px);
+  aspect-ratio: 9 / 16;
+}
+
+.frameLandscape {
+  width: 100%;
+  max-width: 720px;
+  aspect-ratio: 16 / 9;
+}
+
+.frameSquare {
+  width: min(100%, 460px);
+  aspect-ratio: 1 / 1;
+}
+
+.mapContainer {
+  position: absolute;
+  inset: 0;
+}
+
+.recenterButton {
+  position: absolute;
+  right: 0.6rem;
+  bottom: 0.6rem;
+  z-index: 2;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.78rem;
+  font-weight: 500;
+  border: 1px solid rgba(236, 238, 242, 0.18);
+  border-radius: 8px;
+  background: rgba(11, 13, 17, 0.72);
+  color: var(--st-text);
+  cursor: pointer;
+}
+
+.recenterButton:hover {
+  background: rgba(11, 13, 17, 0.92);
+  border-color: rgba(236, 238, 242, 0.32);
+}
+
+.resultVideo {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  width: 100%;
+  height: 100%;
+  background: #000;
+  object-fit: cover;
+  animation: resultIn 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes resultIn {
+  from {
+    opacity: 0;
+    transform: scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .resultVideo {
+    animation: none;
+  }
+  .progressFill {
+    transition: none;
+  }
+}
+
+.stageCaption {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: center;
+  column-gap: 0.6rem;
+  row-gap: 0.15rem;
+  margin: 0;
+  font-size: 0.88rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--st-muted);
+}
+
+.stageCaption strong {
+  font-weight: 600;
+  color: var(--st-text);
+}
+
+.captionDivider {
+  color: rgba(236, 238, 242, 0.28);
+}
+
+/* ---------- Rail ---------- */
+
+.rail {
+  grid-area: rail;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-width: 0;
+  padding: 1.4rem 1.25rem 1.6rem;
+  border-top: 1px solid var(--st-border);
+  background: var(--st-bg);
+}
+
+@media (min-width: 997px) {
+  .rail {
+    border-top: 0;
+    border-left: 1px solid var(--st-border);
+  }
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-inline-size: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.controls:disabled .group {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.groupLegend {
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--st-muted);
+}
+
+.controlRow {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.controlRow input[type='range'] {
+  width: 100%;
+  accent-color: var(--st-accent);
+}
+
+.controlLabel {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.4rem;
+  font-size: 0.84rem;
+  font-weight: 500;
+  color: var(--st-text);
+}
+
+.controlValue {
+  font-weight: 400;
+  font-variant-numeric: tabular-nums;
+  color: var(--st-muted);
+}
+
+/* Theme swatches: real rendered thumbnails, 17 of them */
+
+.themeGrid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.45rem;
+}
+
+.themeChip {
+  position: relative;
+  aspect-ratio: 3 / 4;
+  padding: 0;
+  border: 1px solid var(--st-border);
+  border-radius: 7px;
+  background-color: var(--st-panel);
+  background-size: cover;
+  background-position: center;
+  cursor: pointer;
+}
+
+.themeChip:hover {
+  border-color: rgba(236, 238, 242, 0.35);
+}
+
+.themeChipSelected,
+.themeChipSelected:hover {
+  border-color: var(--st-accent);
+  box-shadow: 0 0 0 2px var(--st-accent);
+}
+
+.segmented {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.segment {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 2.25rem;
+  padding: 0.35rem 0.55rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  text-align: center;
+  border: 1px solid var(--st-border);
+  border-radius: 8px;
+  background: var(--st-panel);
+  color: var(--st-text);
+  cursor: pointer;
+}
+
+.segment:hover {
+  border-color: rgba(236, 238, 242, 0.3);
+}
+
+.segmentActive,
+.segmentActive:hover {
+  border-color: var(--st-accent);
+  background: var(--st-accent);
+  color: #fff;
+}
+
+.colorRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.colorRow input[type='color'] {
+  width: 2.9rem;
+  height: 2.1rem;
+  padding: 0.15rem;
+  border: 1px solid var(--st-border);
+  border-radius: 8px;
+  background: var(--st-panel);
+  cursor: pointer;
+}
+
+.linkButton {
+  padding: 0;
+  border: none;
+  background: none;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--st-accent);
+  cursor: pointer;
+}
+
+.linkButton:hover {
+  text-decoration: underline;
+}
+
+.railError {
+  margin: 0;
+  padding: 0.6rem 0.8rem;
+  border: 1px solid rgba(255, 107, 96, 0.35);
+  border-radius: 8px;
+  background: rgba(255, 107, 96, 0.1);
+  color: var(--st-danger);
+  font-size: 0.84rem;
+  line-height: 1.45;
+}
+
+/* ---------- Action bar ---------- */
+
+.actionBar {
+  grid-area: bar;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem 1rem;
+  min-height: 4rem;
+  padding: 0.85rem 1.25rem;
+  border-top: 1px solid var(--st-border);
+  background: var(--st-panel);
+}
+
+@media (min-width: 997px) {
+  .actionBar {
+    padding: 0.85rem 2rem;
+  }
+}
+
+.barStatus {
+  flex: 1 1 16rem;
+  min-width: 0;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  color: var(--st-muted);
+}
+
+.barStatus strong {
+  font-weight: 600;
+  color: var(--st-text);
+}
+
+.barActions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.renderButton {
+  min-height: 2.75rem;
+  padding: 0.55rem 1.6rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  border: none;
+  border-radius: 10px;
+  background: var(--st-accent);
+  color: #fff;
+  cursor: pointer;
+}
+
+.renderButton:hover:not(:disabled) {
+  background: var(--st-accent-strong);
+}
+
+.renderButton:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.ghostButton {
+  min-height: 2.75rem;
+  padding: 0.55rem 1.1rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  border: 1px solid var(--st-border);
+  border-radius: 10px;
+  background: transparent;
+  color: var(--st-text);
+  cursor: pointer;
+}
+
+.ghostButton:hover {
+  border-color: rgba(236, 238, 242, 0.35);
+}
+
+.downloadButton {
+  display: inline-block;
+  min-height: 2.75rem;
+  padding: 0.62rem 1.6rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  border-radius: 10px;
+  background: var(--st-accent);
+  color: #fff;
+}
+
+.downloadButton:hover {
+  background: var(--st-accent-strong);
+  color: #fff;
+  text-decoration: none;
+}
+
+.progressTrack {
+  position: relative;
+  flex: 1 1 14rem;
+  height: 0.55rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(236, 238, 242, 0.12);
+}
+
+.progressFill {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: var(--st-accent);
+  transform-origin: left center;
+  transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* Shared focus treatment on the dark canvas */
+
+.studio :is(button, a, input, [role='radio']):focus-visible {
+  outline: 2px solid var(--st-accent);
+  outline-offset: 2px;
+}
+
+.loadingNote {
+  margin: 0;
+  color: var(--st-muted);
+}

--- a/src/components/VideoStudio/VideoStudioEditor.js
+++ b/src/components/VideoStudio/VideoStudioEditor.js
@@ -1,0 +1,188 @@
+// Assembles the studio surface: stage (preview / result), control rail, and
+// the action bar that owns the render lifecycle. Loaded lazily behind
+// BrowserOnly — maplibre and mp4-muxer never reach the SSR bundle.
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { DAWARICH_BLUE } from '../../utils/videoExport/colorUtil';
+import { buildStatRows, computeTrackStats } from '../../utils/videoExport/videoStats';
+import { isVideoExportSupported } from '../../utils/videoExport/mp4Encoder';
+import styles from './VideoStudio.module.css';
+import { useVideoStudio } from './useVideoStudio';
+import VideoControls from './VideoControls';
+import VideoPreviewMap from './VideoPreviewMap';
+
+export default function VideoStudioEditor({ trackGeojson, points, fallbackBounds }) {
+  const studio = useVideoStudio(trackGeojson);
+  const [supported, setSupported] = useState(true);
+  const [rendering, setRendering] = useState(false);
+  const [progress, setProgress] = useState({ done: 0, total: 0 });
+  const [result, setResult] = useState(null);
+  const [renderError, setRenderError] = useState(null);
+  const abortRef = useRef(null);
+
+  const stats = useMemo(() => computeTrackStats(points), [points]);
+  const statRows = useMemo(() => buildStatRows(stats, studio.units), [stats, studio.units]);
+
+  useEffect(() => {
+    setSupported(isVideoExportSupported());
+  }, []);
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+  useEffect(() => () => result && URL.revokeObjectURL(result.url), [result]);
+
+  // The finished video overlays the preview frame, so a settings change while
+  // it is showing would edit the map invisibly — dismiss the result instead
+  // and drop back to the live preview.
+  const settingsKey = JSON.stringify([
+    studio.themeKey,
+    studio.formatKey,
+    studio.trackColor,
+    studio.trackWidth,
+    studio.cameraMode,
+    studio.followZoom,
+    studio.durationSec,
+    studio.units,
+  ]);
+  const lastSettingsRef = useRef(settingsKey);
+  useEffect(() => {
+    if (lastSettingsRef.current === settingsKey) return;
+    lastSettingsRef.current = settingsKey;
+    setResult(null);
+  }, [settingsKey]);
+
+  const handleRender = async () => {
+    if (!studio.style || rendering) return;
+    setRenderError(null);
+    setResult(null);
+    setRendering(true);
+    setProgress({ done: 0, total: 0 });
+    const controller = new AbortController();
+    abortRef.current = controller;
+    try {
+      const { renderRouteVideo } = await import('../../utils/videoExport/videoRenderer');
+      const { blob } = await renderRouteVideo({
+        style: studio.style,
+        trackGeojson,
+        points,
+        stats,
+        width: studio.format.width,
+        height: studio.format.height,
+        durationSec: studio.durationSec,
+        cameraMode: studio.cameraMode,
+        followZoom: studio.followZoom,
+        accent: studio.trackColor ?? studio.theme?.route ?? DAWARICH_BLUE,
+        units: studio.units,
+        onProgress: (done, total) => setProgress({ done, total }),
+        signal: controller.signal,
+      });
+      setResult({ url: URL.createObjectURL(blob), sizeBytes: blob.size });
+    } catch (error) {
+      if (error.message !== 'Render cancelled') setRenderError(error.message);
+    } finally {
+      setRendering(false);
+      abortRef.current = null;
+    }
+  };
+
+  const sizeMb = result ? (result.sizeBytes / (1024 * 1024)).toFixed(1) : null;
+
+  return (
+    <div className={styles.studio}>
+      <div className={styles.stage}>
+        {studio.style ? (
+          <VideoPreviewMap
+            style={studio.style}
+            trackGeojson={trackGeojson}
+            fallbackBounds={fallbackBounds}
+            formatKey={studio.formatKey}
+            resultUrl={result?.url ?? null}
+            statRows={statRows}
+          />
+        ) : (
+          <p className={styles.loadingNote}>
+            {studio.themeError ? 'The map theme failed to load.' : 'Loading the map theme…'}
+          </p>
+        )}
+      </div>
+
+      <aside className={styles.rail} aria-label="Video settings">
+        <VideoControls studio={studio} disabled={rendering} />
+      </aside>
+
+      <div className={styles.actionBar}>
+        {rendering ? (
+          <>
+            <div className={styles.barStatus} data-testid="video-progress" aria-live="polite">
+              Rendering frame <strong>{progress.done}</strong> of{' '}
+              <strong>{progress.total || '…'}</strong>
+            </div>
+            <div className={styles.progressTrack} aria-hidden="true">
+              <div
+                className={styles.progressFill}
+                style={{
+                  transform: `scaleX(${progress.total ? progress.done / progress.total : 0})`,
+                }}
+              />
+            </div>
+            <div className={styles.barActions}>
+              <button
+                type="button"
+                className={styles.ghostButton}
+                onClick={() => abortRef.current?.abort()}
+              >
+                Cancel
+              </button>
+            </div>
+          </>
+        ) : result ? (
+          <>
+            <div className={styles.barStatus} aria-live="polite">
+              <strong>Your video is ready.</strong> Playing above — download it or go back to
+              editing.
+            </div>
+            <div className={styles.barActions}>
+              <button
+                type="button"
+                className={styles.ghostButton}
+                onClick={() => setResult(null)}
+                data-testid="video-edit-again"
+              >
+                Edit again
+              </button>
+              <a
+                className={styles.downloadButton}
+                href={result.url}
+                download="dawarich-route-video.mp4"
+                data-testid="video-download"
+              >
+                Download MP4 · {sizeMb} MB
+              </a>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className={styles.barStatus} role={renderError || !supported ? 'alert' : undefined}>
+              {renderError ? (
+                <span className={styles.railError}>{renderError}</span>
+              ) : !supported ? (
+                'This browser cannot encode video files — the preview works, but rendering needs a current Chrome, Edge, Safari, or Firefox.'
+              ) : (
+                'Rendered on your device — your file never leaves the browser.'
+              )}
+            </div>
+            <div className={styles.barActions}>
+              <button
+                type="button"
+                className={styles.renderButton}
+                onClick={handleRender}
+                disabled={!supported || !studio.style}
+                data-testid="video-render"
+              >
+                Render video
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/VideoStudio/useVideoStudio.js
+++ b/src/components/VideoStudio/useVideoStudio.js
@@ -1,0 +1,78 @@
+// All video studio state plus the derived MapLibre style. DOM-free on
+// purpose (mirrors usePosterStudio): safe to load outside the lazy boundary.
+import { useEffect, useMemo, useState } from 'react';
+import { loadThemeTokens, resolveTheme, THEME_KEYS } from '../../lib/poster-studio/data/theme_loader';
+import { buildPosterStyle } from '../../lib/poster-studio/render/style_builder';
+import { DAWARICH_BLUE } from '../../utils/videoExport/colorUtil';
+
+export const VIDEO_FORMATS = {
+  portrait: { width: 1080, height: 1920, label: 'Story · 9:16' },
+  landscape: { width: 1920, height: 1080, label: 'Wide · 16:9' },
+  square: { width: 1080, height: 1080, label: 'Feed · 1:1' },
+};
+
+export const DEFAULT_VIDEO_THEME_KEY = 'noir';
+export const MIN_DURATION_SEC = 8;
+export const MAX_DURATION_SEC = 30;
+
+export function useVideoStudio(trackGeojson) {
+  const [themeKey, setThemeKey] = useState(DEFAULT_VIDEO_THEME_KEY);
+  const [tokens, setTokens] = useState(null);
+  const [themeError, setThemeError] = useState(null);
+  const [formatKey, setFormatKey] = useState('portrait');
+  const [durationSec, setDurationSec] = useState(15);
+  const [cameraMode, setCameraMode] = useState('overview');
+  const [followZoom, setFollowZoom] = useState(13.5);
+  const [trackColor, setTrackColor] = useState(DAWARICH_BLUE);
+  const [trackWidth, setTrackWidth] = useState(1.2);
+  const [units, setUnits] = useState('km');
+
+  useEffect(() => {
+    let cancelled = false;
+    setThemeError(null);
+    loadThemeTokens(themeKey)
+      .then((loaded) => {
+        if (!cancelled) setTokens(loaded);
+      })
+      .catch((error) => {
+        if (!cancelled) setThemeError(error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [themeKey]);
+
+  const theme = useMemo(() => (tokens ? resolveTheme(tokens) : null), [tokens]);
+  const format = VIDEO_FORMATS[formatKey];
+  const style = useMemo(
+    () =>
+      theme
+        ? buildPosterStyle({ theme, trackGeojson, trackColor, trackOpacity: 1, trackWidth })
+        : null,
+    [theme, trackGeojson, trackColor, trackWidth],
+  );
+
+  return {
+    themeKey,
+    setThemeKey,
+    themeKeys: THEME_KEYS,
+    theme,
+    themeError,
+    formatKey,
+    setFormatKey,
+    format,
+    durationSec,
+    setDurationSec,
+    cameraMode,
+    setCameraMode,
+    followZoom,
+    setFollowZoom,
+    trackColor,
+    setTrackColor,
+    trackWidth,
+    setTrackWidth,
+    units,
+    setUnits,
+    style,
+  };
+}

--- a/src/data/tool-related-links.js
+++ b/src/data/tool-related-links.js
@@ -99,6 +99,7 @@ const RELATED = {
 
   // ───── Google Timeline tools ─────
   'google-timeline-converter': [
+    { href: '/tools/route-video-maker/', label: 'Route Video Maker', note: 'Turn your Timeline into a travel video' },
     { href: '/tools/google-timeline-splitter/', label: 'Timeline Splitter', note: 'Split a giant Takeout export' },
     { href: '/tools/timeline-merger/',  label: 'Timeline Merger',    note: 'Combine multiple exports' },
     { href: '/blog/migrating-from-google-location-history-to-dawarich/', label: 'Migration guide', note: 'Step-by-step move to Dawarich' },
@@ -119,6 +120,7 @@ const RELATED = {
     { href: '/blog/whats-inside-your-google-timeline-export/', label: "What's in a Timeline export", note: 'Format reference' },
   ],
   'timeline-visualizer': [
+    { href: '/tools/route-video-maker/', label: 'Route Video Maker', note: 'Turn the same file into a video' },
     { href: '/interactive-map/',        label: 'Interactive Map',    note: 'Full visualization in Dawarich' },
     { href: '/tools/map-poster-maker/', label: 'Map Poster Maker',   note: 'Turn the same file into wall art' },
     { href: '/tools/timeline-statistics/', label: 'Timeline Statistics', note: 'Numbers behind the map' },
@@ -152,8 +154,14 @@ const RELATED = {
   ],
   'map-poster-maker': [
     { href: '/poster-studio/',          label: 'Poster Studio in Dawarich', note: 'Print any month of your history' },
+    { href: '/tools/route-video-maker/', label: 'Route Video Maker', note: 'Same file, animated video' },
     { href: '/tools/heatmap-generator/', label: 'Heatmap Generator', note: 'Density view of the same file' },
     { href: '/tools/gpx-merger/',       label: 'GPX Merger',         note: 'Combine tracks into one poster' },
+  ],
+  'route-video-maker': [
+    { href: '/tools/map-poster-maker/', label: 'Map Poster Maker',   note: 'Same file, printable poster' },
+    { href: '/tools/heatmap-generator/', label: 'Heatmap Generator', note: 'Density view of the same file' },
+    { href: '/tools/gpx-merger/',       label: 'GPX Merger',         note: 'Combine tracks into one video' },
   ],
   'photo-geotagging': [
     { href: '/integrations/',           label: 'Photo Integrations', note: 'Immich & PhotoPrism geodata import' },

--- a/src/pages/tools/index.js
+++ b/src/pages/tools/index.js
@@ -71,6 +71,12 @@ const freeTools = [
     description: 'Compose a map poster from any GPS file — 17 themes, PNG/PDF export, optional prints.',
   },
   {
+    to: '/tools/route-video-maker',
+    icon: '🎬',
+    title: 'Route Video Maker',
+    description: 'Animate any GPS track into a shareable MP4 — the route draws itself across a styled map.',
+  },
+  {
     to: '/tools/gpx-merger',
     icon: '🔗',
     title: 'GPX Track Merger',

--- a/src/pages/tools/route-video-maker.js
+++ b/src/pages/tools/route-video-maker.js
@@ -1,0 +1,442 @@
+import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import Head from '@docusaurus/Head';
+import Layout from '@theme/Layout';
+import PersonalizedCTA from '@site/src/components/PersonalizedCTA';
+import RelatedTools from '@site/src/components/RelatedTools';
+import SaveToAccountButton from '@site/src/components/SaveToAccountButton';
+import { detectGoogleSource } from '@site/src/utils/detectGoogleSource';
+import { fetchDemoRoutePoints } from '@site/src/utils/demoPosterRoute';
+import { parseFile } from '@site/src/utils/heatmapUtils';
+import { pointsToTrackGeoJSON } from '@site/src/utils/posterTrack';
+import { detectFormat } from '@site/src/utils/timelineParser';
+import styles from './route-video-maker.module.css';
+
+const LazyVideoStudioEditor = React.lazy(
+  () => import('@site/src/components/VideoStudio/VideoStudioEditor'),
+);
+
+const pageTitle = 'GPX & Google Timeline to Video — Free Route Video Maker';
+const pageDescription =
+  'Free GPX to video converter — turn GPX, Google Timeline, KML, FIT or TCX files into an animated route replay video in your browser. 17 map themes, MP4 export, no upload, no account.';
+const pageUrl = 'https://dawarich.app/tools/route-video-maker/';
+const imageUrl = 'https://dawarich.app/img/meta-image.png';
+
+const MAX_FILE_BYTES = 100 * 1024 * 1024;
+
+// Central Berlin: the studio opens on the demo route until a file is dropped.
+const BERLIN_FALLBACK_BOUNDS = [
+  [13.35, 52.49],
+  [13.46, 52.55],
+];
+
+const EMPTY_TRACK = { type: 'FeatureCollection', features: [] };
+
+const faqItems = [
+  {
+    question: 'How do I make a video from my GPS track?',
+    answer:
+      'The studio opens with a demo route through Berlin so you can try it immediately. Drop your own GPX, Google Timeline JSON, GeoJSON, KML, KMZ, FIT or TCX file to replace it, pick a map theme and format, and press Render. The route draws itself across the map, ends on a stats card, and downloads as an MP4 you can post anywhere.',
+  },
+  {
+    question: 'Is my location data private?',
+    answer:
+      "Your file is parsed and the video is rendered entirely in your browser — nothing is uploaded to any server. To draw the map, tiles for the area your data covers are requested from Dawarich's tile server, the same as any online map. The only optional upload is \"Save to my account\", which imports your file during signup.",
+  },
+  {
+    question: 'Is it free? Do I need an account?',
+    answer:
+      'Yes, free — no account, no signup, unlimited renders. Every video carries a small dawarich.app credit in its summary frame.',
+  },
+  {
+    question: 'What formats and resolutions can I export?',
+    answer:
+      'Three formats: vertical 1080 × 1920 for Stories, Reels and TikTok, widescreen 1920 × 1080 for YouTube, and square 1080 × 1080 for feed posts. Videos are 8–30 seconds long, 30 frames per second, exported as MP4 (H.264 where the browser supports it).',
+  },
+  {
+    question: 'Which browsers can render videos?',
+    answer:
+      'Rendering uses the WebCodecs API: current versions of Chrome, Edge and Safari work, as do recent Firefox releases. On unsupported browsers the preview still works — only the render step is unavailable.',
+  },
+  {
+    question: 'Which files work with the video maker?',
+    answer:
+      'GPX tracks, Google Timeline exports (Records.json, Semantic Location History and phone Takeout formats), GeoJSON, KML, KMZ, FIT and TCX. You can drop several files at once — they are combined into one route, split wherever there is a gap of more than an hour.',
+  },
+  {
+    question: 'Can I make a video from my Google Maps Timeline?',
+    answer:
+      'Yes — export your Timeline from the Google Maps app (Settings → Personal content → Export Timeline data) or via Google Takeout, then drop the JSON file here. The video plays your travel history day by day with dates and distance. To inspect the data first, try the Google Timeline Visualizer; to convert it into other formats, the Google Timeline Converter.',
+  },
+  {
+    question: 'Is this an alternative to apps like Relive?',
+    answer:
+      'For route replay videos, yes — with no app install and no account. Relive builds 3D videos from activities tracked in its own app; this tool animates any GPS file you already have, including whole months of location history, and renders the MP4 locally in your browser instead of uploading your movements to a server.',
+  },
+  {
+    question: 'Do Strava and Garmin exports work?',
+    answer:
+      'Yes. Export a single activity as GPX (or TCX) from Strava or Garmin Connect and drop it here — a FIT file straight off a Garmin device works too. One activity makes the cleanest video: the route draws itself from start to finish with your distance and dates.',
+  },
+];
+
+function jsonLdWebApplication() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Route Video Maker',
+    url: pageUrl,
+    description: pageDescription,
+    applicationCategory: 'MultimediaApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  };
+}
+
+function jsonLdHowTo() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'HowTo',
+    name: 'How to Create an Animated Video from Your GPS Data',
+    description:
+      'Turn a GPS track or your Google Timeline history into an animated route replay video, free and in the browser.',
+    step: [
+      {
+        '@type': 'HowToStep',
+        name: 'Upload a location file',
+        text: 'The studio opens with a Berlin demo route. Drag and drop a GPX, Google Timeline JSON, GeoJSON, KML, KMZ, FIT or TCX file to replace it with your own track.',
+      },
+      {
+        '@type': 'HowToStep',
+        name: 'Style your video',
+        text: 'Pick one of 17 map themes, choose vertical, widescreen or square format, set the length, and decide whether the camera shows the whole route or follows the line as it draws.',
+      },
+      {
+        '@type': 'HowToStep',
+        name: 'Render and download',
+        text: 'Press Render — the video is encoded in your browser and downloads as an MP4. A live HUD shows the date, distance and progress while the route draws, ending on a summary frame with the total distance and date range.',
+      },
+    ],
+    tool: { '@type': 'HowToTool', name: 'Route Video Maker by Dawarich' },
+  };
+}
+
+function jsonLdFaq() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqItems.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: { '@type': 'Answer', text: item.answer },
+    })),
+  };
+}
+
+function jsonLdBreadcrumbs() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://dawarich.app' },
+      { '@type': 'ListItem', position: 2, name: 'Free Tools', item: 'https://dawarich.app/tools' },
+      { '@type': 'ListItem', position: 3, name: 'Route Video Maker', item: pageUrl },
+    ],
+  };
+}
+
+export default function RouteVideoMaker() {
+  const [files, setFiles] = useState([]);
+  const [points, setPoints] = useState([]);
+  const [showDemo, setShowDemo] = useState(true);
+  const [error, setError] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [dragActive, setDragActive] = useState(false);
+
+  const [demoPoints, setDemoPoints] = useState(null);
+  const [demoError, setDemoError] = useState(null);
+
+  const uploadedTrack = useMemo(
+    () => (points.length > 0 ? pointsToTrackGeoJSON(points) : null),
+    [points],
+  );
+
+  useEffect(() => {
+    if (!showDemo || uploadedTrack || demoPoints) return undefined;
+    let cancelled = false;
+    fetchDemoRoutePoints()
+      .then((loaded) => {
+        if (!cancelled) setDemoPoints(loaded);
+      })
+      .catch((loadError) => {
+        if (!cancelled) setDemoError(loadError);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [showDemo, uploadedTrack, demoPoints]);
+
+  const demoTrack = useMemo(
+    () => (demoPoints ? pointsToTrackGeoJSON(demoPoints) : null),
+    [demoPoints],
+  );
+  const activeTrack = uploadedTrack ?? (showDemo && demoTrack ? demoTrack : EMPTY_TRACK);
+  const activePoints = uploadedTrack ? points : showDemo && demoPoints ? demoPoints : [];
+  const trackKey = uploadedTrack
+    ? files.map((f) => f.name).join('|')
+    : showDemo && demoTrack
+      ? 'demo'
+      : 'empty';
+
+  const handleFiles = async (newFiles) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const nextFiles = [...files];
+      const nextPoints = [...points];
+      for (const file of newFiles) {
+        if (file.size > MAX_FILE_BYTES) {
+          setError(`${file.name} is larger than 100 MB — split it first (try the GPS File Splitter).`);
+          continue;
+        }
+        try {
+          let format = null;
+          if (file.name.toLowerCase().endsWith('.json')) {
+            try {
+              format = detectFormat(JSON.parse(await file.text()));
+            } catch {
+              format = null;
+            }
+          }
+          const filePoints = await parseFile(file);
+          nextPoints.push(...filePoints);
+          nextFiles.push({ name: file.name, pointCount: filePoints.length, blob: file, format });
+        } catch (parseError) {
+          setError(`Error parsing ${file.name}: ${parseError.message}`);
+        }
+      }
+      if (nextFiles.length > files.length) {
+        setFiles(nextFiles);
+        setPoints(nextPoints);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleDrag = useCallback((event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (event.type === 'dragenter' || event.type === 'dragover') setDragActive(true);
+    else if (event.type === 'dragleave') setDragActive(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setDragActive(false);
+      if (event.dataTransfer.files?.length > 0) handleFiles(Array.from(event.dataTransfer.files));
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [files, points],
+  );
+
+  const handleClear = () => {
+    setFiles([]);
+    setPoints([]);
+    setShowDemo(true);
+    setError(null);
+  };
+
+  const getOriginalFiles = useCallback(
+    () => files.map((f) => ({ name: f.name, blob: f.blob })).filter((f) => f.blob),
+    [files],
+  );
+
+  return (
+    <Layout title={pageTitle} description={pageDescription}>
+      <Head>
+        <meta name="title" content={pageTitle} />
+        <meta name="description" content={pageDescription} />
+        <meta
+          name="keywords"
+          content="gpx to video, route video maker, google timeline video, animated route map, gpx route animation, route replay video, running route video, road trip video, travel recap video, map animation"
+        />
+        <link rel="canonical" href={pageUrl} />
+
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={pageUrl} />
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={pageDescription} />
+        <meta property="og:image" content={imageUrl} />
+
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:url" content={pageUrl} />
+        <meta name="twitter:title" content={pageTitle} />
+        <meta name="twitter:description" content={pageDescription} />
+        <meta name="twitter:image" content={imageUrl} />
+
+        <script type="application/ld+json">{JSON.stringify(jsonLdWebApplication())}</script>
+        <script type="application/ld+json">{JSON.stringify(jsonLdHowTo())}</script>
+        <script type="application/ld+json">{JSON.stringify(jsonLdFaq())}</script>
+        <script type="application/ld+json">{JSON.stringify(jsonLdBreadcrumbs())}</script>
+      </Head>
+      <main>
+        <div className={styles.container}>
+          <div className={styles.header}>
+            <h1>Turn any GPS route into an animated map video</h1>
+            <p>
+              Your route, drawn across the map — as a video. Drop any GPX, Google Timeline, KML,
+              FIT or TCX file and watch your run, ride or road trip draw itself across a styled
+              map, then download it as an MP4 for Stories, Reels, TikTok or YouTube. Rendered
+              entirely in your browser, no account.
+            </p>
+            <p className={styles.valueStrip}>
+              17 map themes · vertical, widescreen &amp; square · MP4 export · €0 · no upload
+            </p>
+          </div>
+
+          <div className={styles.toolbar}>
+            {uploadedTrack ? (
+              <div className={styles.toolbarStatus}>
+                <span className={styles.studioBarLabel}>
+                  {files.length} file{files.length === 1 ? '' : 's'} ·{' '}
+                  {points.length.toLocaleString()} points
+                </span>
+                <button
+                  type="button"
+                  className={styles.clearButton}
+                  data-testid="video-start-over"
+                  onClick={handleClear}
+                >
+                  Start over
+                </button>
+              </div>
+            ) : (
+              <label className={styles.demoToggle}>
+                <input
+                  type="checkbox"
+                  data-testid="demo-toggle"
+                  checked={showDemo}
+                  onChange={(event) => setShowDemo(event.target.checked)}
+                />
+                <span>Show demo data</span>
+              </label>
+            )}
+
+            <div
+              className={`${styles.dropZoneCompact} ${dragActive ? styles.dragActive : ''}`}
+              onDragEnter={handleDrag}
+              onDragLeave={handleDrag}
+              onDragOver={handleDrag}
+              onDrop={handleDrop}
+              data-testid="video-dropzone"
+            >
+              <svg
+                className={styles.dropIcon}
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M7 16a4 4 0 0 1-.88-7.903A5 5 0 1 1 15.9 6L16 6a5 5 0 0 1 1 9.9" />
+                <path d="M15 13l-3-3m0 0l-3 3m3-3v9" />
+              </svg>
+              <span className={styles.dropText}>
+                <span className={styles.dropTitle}>
+                  {uploadedTrack ? 'Add more files' : 'Drop your location file here or click to browse'}
+                </span>
+                <span className={styles.supportedFormats}>
+                  GPX, FIT, TCX, GeoJSON, KML, KMZ, Google Timeline JSON
+                </span>
+              </span>
+              <input
+                aria-label="Choose files to make a video from"
+                type="file"
+                className={styles.fileInput}
+                accept=".gpx,.fit,.tcx,.geojson,.json,.kml,.kmz"
+                multiple
+                onChange={(event) => {
+                  if (event.target.files?.length > 0) handleFiles(Array.from(event.target.files));
+                }}
+              />
+            </div>
+          </div>
+
+          {isLoading && <p className={styles.loadingNote}>Processing files…</p>}
+          {error && (
+            <p className={styles.errorMessage} role="alert">
+              {error}
+            </p>
+          )}
+          {files.length > 0 && !uploadedTrack && !isLoading && (
+            <p className={styles.errorMessage}>
+              No plottable points found in the uploaded files — check that they contain location
+              data.
+            </p>
+          )}
+          {demoError && !uploadedTrack && showDemo && (
+            <p className={styles.errorMessage}>
+              The demo route failed to load — drop your own file to start.
+            </p>
+          )}
+
+          <section className={styles.studioSection}>
+            <BrowserOnly fallback={<div className={styles.loadingNote}>Loading the studio…</div>}>
+              {() => (
+                <Suspense fallback={<div className={styles.loadingNote}>Loading the studio…</div>}>
+                  <LazyVideoStudioEditor
+                    trackGeojson={activeTrack}
+                    points={activePoints}
+                    fallbackBounds={BERLIN_FALLBACK_BOUNDS}
+                    key={trackKey}
+                  />
+                </Suspense>
+              )}
+            </BrowserOnly>
+            {files.length > 0 && uploadedTrack && (
+              <div className={styles.saveSection}>
+                <p className={styles.saveIntro}>
+                  Want this data in your Dawarich account too? We&apos;ll import it during signup —
+                  no second upload needed.
+                </p>
+                <SaveToAccountButton
+                  toolName="route-video-maker"
+                  sourceHint={detectGoogleSource(files)}
+                  getFiles={getOriginalFiles}
+                  disabled={files.length === 0}
+                />
+              </div>
+            )}
+          </section>
+
+          <div className={styles.faqSection}>
+            <h2>Frequently Asked Questions</h2>
+            <div className={styles.faqList}>
+              {faqItems.map((item) => (
+                <details key={item.question} className={styles.faqItem}>
+                  <summary className={styles.faqQuestion}>{item.question}</summary>
+                  <p className={styles.faqAnswer}>{item.answer}</p>
+                </details>
+              ))}
+            </div>
+          </div>
+
+          <PersonalizedCTA
+            toolName="route-video-maker"
+            headline={
+              uploadedTrack
+                ? `Your video is built from <strong>${points.length.toLocaleString()}</strong> GPS points from one file. Dawarich records every route automatically — any trip in your history becomes a video. 7-day free trial, 14-day refund, cancel anytime.`
+                : 'One file makes one video. Dawarich records every route automatically — any trip in your history becomes a video. 7-day free trial, 14-day refund, cancel anytime.'
+            }
+          />
+          <RelatedTools slug="route-video-maker" />
+        </div>
+      </main>
+    </Layout>
+  );
+}

--- a/src/pages/tools/route-video-maker.module.css
+++ b/src/pages/tools/route-video-maker.module.css
@@ -1,0 +1,231 @@
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2.25rem 1rem 3rem;
+}
+
+.header {
+  max-width: 720px;
+  margin: 0 auto 1.9rem;
+  text-align: center;
+}
+
+.header h1 {
+  margin-bottom: 0.65rem;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  line-height: 1.12;
+  letter-spacing: -0.025em;
+  text-wrap: balance;
+}
+
+.header p {
+  max-width: 620px;
+  margin: 0 auto;
+  font-size: 1.02rem;
+  line-height: 1.55;
+  color: var(--ifm-font-color-secondary);
+}
+
+.header .valueStrip {
+  margin-top: 0.9rem;
+  font-size: 0.84rem;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+  color: var(--ifm-font-color-secondary);
+}
+
+/* ---------- Toolbar: demo toggle + upload ---------- */
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.toolbarStatus {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.demoToggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.demoToggle input {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--ifm-color-primary);
+}
+
+.demoToggle input:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
+.dropZoneCompact {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex: 1;
+  min-width: 280px;
+  max-width: 540px;
+  padding: 0.65rem 0.9rem;
+  border: 1.5px dashed var(--ifm-color-emphasis-300);
+  border-radius: 10px;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.dropZoneCompact:hover,
+.dropZoneCompact:focus-within,
+.dragActive {
+  border-color: var(--ifm-color-primary);
+  background: rgba(37, 99, 235, 0.05);
+}
+
+:global([data-theme='dark']) .dropZoneCompact:hover,
+:global([data-theme='dark']) .dropZoneCompact:focus-within,
+:global([data-theme='dark']) .dragActive {
+  background: rgba(96, 165, 250, 0.09);
+}
+
+.dropIcon {
+  flex-shrink: 0;
+  width: 1.4rem;
+  height: 1.4rem;
+  color: var(--ifm-color-primary);
+}
+
+.dropText {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.dropTitle {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.supportedFormats {
+  font-size: 0.74rem;
+  color: var(--ifm-font-color-secondary);
+}
+
+.fileInput {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.studioBarLabel {
+  font-size: 0.9rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--ifm-font-color-secondary);
+}
+
+.clearButton {
+  padding: 0.32rem 0.8rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-font-color-base);
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.clearButton:hover {
+  background: var(--ifm-color-emphasis-100);
+  border-color: var(--ifm-color-emphasis-400, var(--ifm-color-emphasis-300));
+}
+
+.clearButton:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
+/* ---------- Notes ---------- */
+
+.loadingNote {
+  margin: 0.75rem 0;
+  text-align: center;
+  color: var(--ifm-font-color-secondary);
+}
+
+.errorMessage {
+  margin: 0.75rem 0;
+  padding: 0.6rem 0.9rem;
+  border-radius: 8px;
+  background: rgba(220, 38, 38, 0.08);
+  color: var(--ifm-color-danger);
+  font-size: 0.9rem;
+}
+
+/* ---------- Sections below the studio ---------- */
+
+.studioSection {
+  margin-bottom: 3rem;
+}
+
+.saveSection {
+  max-width: 640px;
+  margin: 1.75rem auto 0;
+  text-align: center;
+}
+
+.saveIntro {
+  margin-bottom: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--ifm-font-color-secondary);
+}
+
+.faqSection {
+  max-width: 760px;
+  margin: 0 auto 3rem;
+}
+
+.faqSection h2 {
+  margin-bottom: 1.25rem;
+  text-align: center;
+}
+
+.faqList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.faqItem {
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 10px;
+  background: var(--ifm-background-surface-color);
+}
+
+.faqQuestion {
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.faqAnswer {
+  margin: 0.6rem 0 0;
+  max-width: 70ch;
+  color: var(--ifm-font-color-secondary);
+  line-height: 1.55;
+}

--- a/src/utils/videoExport/cameraPath.js
+++ b/src/utils/videoExport/cameraPath.js
@@ -1,0 +1,43 @@
+// Follow-mode camera: the center is the mean of the route coordinates in a
+// trailing distance window behind the pen tip, so the camera glides through
+// corners instead of snapping, and drifts smoothly across segment jumps
+// (which cost no distance, letting both tails share the window).
+import { sliceAtFraction } from './routeTimeline';
+
+const DEFAULT_WINDOW_M = 400;
+
+// Linear interpolation between two camera poses, for the summary pull-out.
+export function lerpCamera(from, to, t) {
+  const f = Math.max(0, Math.min(1, t));
+  return {
+    center: [
+      from.center[0] + (to.center[0] - from.center[0]) * f,
+      from.center[1] + (to.center[1] - from.center[1]) * f,
+    ],
+    zoom: from.zoom + (to.zoom - from.zoom) * f,
+  };
+}
+
+export function followCenter(timeline, fraction, { windowM = DEFAULT_WINDOW_M } = {}) {
+  const { entries, totalDistance } = timeline;
+  if (entries.length === 0) return null;
+
+  const slice = sliceAtFraction(timeline, fraction);
+  if (!slice.head) return null;
+  if (windowM <= 0) return slice.head;
+
+  const target = Math.max(0, Math.min(1, fraction)) * totalDistance;
+  const from = target - windowM;
+
+  let sumLon = slice.head[0];
+  let sumLat = slice.head[1];
+  let count = 1;
+  for (const entry of entries) {
+    if (entry.dist > target) break;
+    if (entry.dist < from) continue;
+    sumLon += entry.coord[0];
+    sumLat += entry.coord[1];
+    count += 1;
+  }
+  return [sumLon / count, sumLat / count];
+}

--- a/src/utils/videoExport/cameraPath.test.js
+++ b/src/utils/videoExport/cameraPath.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { buildRouteTimeline, sliceAtFraction } from './routeTimeline';
+import { followCenter, lerpCamera } from './cameraPath';
+
+const LINE = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      properties: {},
+      geometry: {
+        type: 'LineString',
+        coordinates: [
+          [13.4, 52.5],
+          [13.41, 52.5],
+          [13.42, 52.5],
+          [13.43, 52.5],
+        ],
+      },
+    },
+  ],
+};
+
+describe('followCenter', () => {
+  const timeline = buildRouteTimeline(LINE);
+
+  it('returns null for an empty timeline', () => {
+    expect(followCenter(buildRouteTimeline(null), 0.5)).toBeNull();
+  });
+
+  it('returns the head itself when the smoothing window is zero', () => {
+    const head = sliceAtFraction(timeline, 0.5).head;
+    const center = followCenter(timeline, 0.5, { windowM: 0 });
+    expect(center[0]).toBeCloseTo(head[0], 6);
+    expect(center[1]).toBeCloseTo(head[1], 6);
+  });
+
+  it('lags behind the head on an eastward line, within the window', () => {
+    const head = sliceAtFraction(timeline, 0.75).head;
+    const center = followCenter(timeline, 0.75, { windowM: 800 });
+    expect(center[0]).toBeLessThan(head[0]);
+    expect(center[0]).toBeGreaterThan(head[0] - 0.015);
+    expect(center[1]).toBeCloseTo(52.5, 5);
+  });
+
+  it('stays finite at the very start of the route', () => {
+    const center = followCenter(timeline, 0, { windowM: 800 });
+    expect(Number.isFinite(center[0])).toBe(true);
+    expect(center[0]).toBeCloseTo(13.4, 4);
+  });
+});
+
+describe('lerpCamera', () => {
+  const from = { center: [13.4, 52.5], zoom: 14 };
+  const to = { center: [13.5, 52.6], zoom: 12 };
+
+  it('returns the endpoints at t 0 and 1', () => {
+    expect(lerpCamera(from, to, 0)).toEqual(from);
+    expect(lerpCamera(from, to, 1)).toEqual(to);
+  });
+
+  it('interpolates center and zoom at the midpoint', () => {
+    const mid = lerpCamera(from, to, 0.5);
+    expect(mid.center[0]).toBeCloseTo(13.45, 6);
+    expect(mid.center[1]).toBeCloseTo(52.55, 6);
+    expect(mid.zoom).toBeCloseTo(13, 6);
+  });
+});

--- a/src/utils/videoExport/codecNegotiation.js
+++ b/src/utils/videoExport/codecNegotiation.js
@@ -1,0 +1,39 @@
+// WebCodecs codec negotiation, decoupled from the browser: the probe function
+// is injected so the preference order stays testable. H.264 first (plays
+// everywhere), then VP9 and AV1 — all three mux into MP4 via mp4-muxer.
+const CODEC_CANDIDATES = [
+  { codec: 'avc1.640028', muxerCodec: 'avc' },
+  { codec: 'avc1.4d0028', muxerCodec: 'avc' },
+  { codec: 'vp09.00.40.08', muxerCodec: 'vp9' },
+  { codec: 'av01.0.08M.08', muxerCodec: 'av1' },
+];
+
+const MIN_BITRATE = 4_000_000;
+const MAX_BITRATE = 16_000_000;
+const BITS_PER_PIXEL_PER_FRAME = 0.15;
+
+export function chooseBitrate(width, height, fps) {
+  const raw = width * height * fps * BITS_PER_PIXEL_PER_FRAME;
+  return Math.round(Math.max(MIN_BITRATE, Math.min(MAX_BITRATE, raw)));
+}
+
+export async function pickSupportedCodec({ width, height, fps, isConfigSupported }) {
+  const bitrate = chooseBitrate(width, height, fps);
+  for (const candidate of CODEC_CANDIDATES) {
+    const config = {
+      codec: candidate.codec,
+      width,
+      height,
+      framerate: fps,
+      bitrate,
+      ...(candidate.muxerCodec === 'avc' ? { avc: { format: 'avc' } } : {}),
+    };
+    try {
+      const result = await isConfigSupported(config);
+      if (result?.supported) return { muxerCodec: candidate.muxerCodec, config };
+    } catch {
+      // An unknown codec string throws in some browsers — same as unsupported.
+    }
+  }
+  return null;
+}

--- a/src/utils/videoExport/codecNegotiation.test.js
+++ b/src/utils/videoExport/codecNegotiation.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { chooseBitrate, pickSupportedCodec } from './codecNegotiation';
+
+describe('chooseBitrate', () => {
+  it('scales with resolution and clamps to a sane range', () => {
+    const portrait = chooseBitrate(1080, 1920, 30);
+    expect(portrait).toBeGreaterThan(4_000_000);
+    expect(portrait).toBeLessThan(16_000_000);
+    expect(chooseBitrate(320, 240, 30)).toBe(4_000_000);
+    expect(chooseBitrate(7680, 4320, 60)).toBe(16_000_000);
+  });
+});
+
+describe('pickSupportedCodec', () => {
+  const dims = { width: 1080, height: 1920, fps: 30 };
+
+  it('prefers H.264 when everything is supported', async () => {
+    const picked = await pickSupportedCodec({
+      ...dims,
+      isConfigSupported: async () => ({ supported: true }),
+    });
+    expect(picked.muxerCodec).toBe('avc');
+    expect(picked.config.codec).toMatch(/^avc1\./);
+    expect(picked.config.width).toBe(1080);
+    expect(picked.config.height).toBe(1920);
+    expect(picked.config.avc).toEqual({ format: 'avc' });
+    expect(picked.config.bitrate).toBeGreaterThan(0);
+  });
+
+  it('falls through to VP9 when H.264 is unavailable', async () => {
+    const picked = await pickSupportedCodec({
+      ...dims,
+      isConfigSupported: async (config) => ({
+        supported: config.codec.startsWith('vp09'),
+      }),
+    });
+    expect(picked.muxerCodec).toBe('vp9');
+    expect(picked.config.avc).toBeUndefined();
+  });
+
+  it('treats a throwing probe as unsupported and keeps going', async () => {
+    const picked = await pickSupportedCodec({
+      ...dims,
+      isConfigSupported: async (config) => {
+        if (config.codec.startsWith('avc1')) throw new Error('bad codec string');
+        return { supported: config.codec.startsWith('av01') };
+      },
+    });
+    expect(picked.muxerCodec).toBe('av1');
+  });
+
+  it('returns null when no codec is supported', async () => {
+    const picked = await pickSupportedCodec({
+      ...dims,
+      isConfigSupported: async () => ({ supported: false }),
+    });
+    expect(picked).toBeNull();
+  });
+});

--- a/src/utils/videoExport/colorUtil.js
+++ b/src/utils/videoExport/colorUtil.js
@@ -1,0 +1,13 @@
+// Hex → rgba() strings for the line-gradient stops. Malformed input falls
+// back to the Dawarich brand blue rather than crashing a render.
+export const DAWARICH_BLUE = '#2563EB';
+
+const FALLBACK_RGB = [37, 99, 235];
+
+export function hexToRgba(hex, alpha) {
+  const match = /^#([0-9a-f]{6})$/i.exec(hex || '');
+  const [r, g, b] = match
+    ? [0, 2, 4].map((i) => Number.parseInt(match[1].slice(i, i + 2), 16))
+    : FALLBACK_RGB;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}

--- a/src/utils/videoExport/colorUtil.test.js
+++ b/src/utils/videoExport/colorUtil.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { DAWARICH_BLUE, hexToRgba } from './colorUtil';
+
+describe('hexToRgba', () => {
+  it('converts hex colors with an alpha', () => {
+    expect(hexToRgba('#FF3B30', 1)).toBe('rgba(255, 59, 48, 1)');
+    expect(hexToRgba('#ff3b30', 0.45)).toBe('rgba(255, 59, 48, 0.45)');
+    expect(hexToRgba('#000000', 0)).toBe('rgba(0, 0, 0, 0)');
+  });
+
+  it('falls back to the Dawarich brand blue for malformed input', () => {
+    expect(DAWARICH_BLUE).toBe('#2563EB');
+    expect(hexToRgba('purple', 0.5)).toBe('rgba(37, 99, 235, 0.5)');
+    expect(hexToRgba(null, 1)).toBe('rgba(37, 99, 235, 1)');
+  });
+});

--- a/src/utils/videoExport/hudFonts.js
+++ b/src/utils/videoExport/hudFonts.js
@@ -1,0 +1,26 @@
+// Loads the HUD's typefaces (Archivo + JetBrains Mono) before rendering, so
+// canvas text draws with the design's fonts instead of the fallback stack.
+// Capped by a timeout: offline or blocked, the render proceeds on fallbacks.
+let fontsPromise = null;
+
+export function ensureHudFonts() {
+  if (fontsPromise) return fontsPromise;
+  fontsPromise = (async () => {
+    if (!document.getElementById('video-hud-fonts')) {
+      const link = document.createElement('link');
+      link.id = 'video-hud-fonts';
+      link.rel = 'stylesheet';
+      link.href =
+        'https://fonts.googleapis.com/css2?family=Archivo:wght@500;600&family=JetBrains+Mono:wght@400;500;700&display=swap';
+      document.head.appendChild(link);
+    }
+    const faces = [
+      '700 54px "JetBrains Mono"',
+      '500 17px "JetBrains Mono"',
+      '400 11px "JetBrains Mono"',
+      '500 18px Archivo',
+    ].map((face) => document.fonts.load(face).catch(() => {}));
+    await Promise.race([Promise.all(faces), new Promise((resolve) => setTimeout(resolve, 3000))]);
+  })();
+  return fontsPromise;
+}

--- a/src/utils/videoExport/hudFormat.js
+++ b/src/utils/videoExport/hudFormat.js
@@ -1,0 +1,55 @@
+// Text formatting for the replay HUD, matching the Replay Frames design:
+// "14 JUN 2026 · 08:41", "08 — 26 JUN 2026", "5d 14h", "DAY 06 / 18".
+// Timestamps are formatted in the viewer's local timezone.
+const KM_PER_MILE = 1.609344;
+const MONTHS = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
+const DAY_MS = 24 * 3600 * 1000;
+
+const pad = (n) => String(n).padStart(2, '0');
+
+export function splitDistance(meters, units = 'km') {
+  if (!Number.isFinite(meters)) return { value: '0', unit: units === 'mi' ? 'mi' : 'm' };
+  if (units === 'mi') return { value: (meters / 1000 / KM_PER_MILE).toFixed(1), unit: 'mi' };
+  if (meters < 1000) return { value: String(Math.round(meters)), unit: 'm' };
+  return { value: (meters / 1000).toFixed(1), unit: 'km' };
+}
+
+export function formatClockDate(ts) {
+  const d = new Date(ts);
+  return `${pad(d.getDate())} ${MONTHS[d.getMonth()]} ${d.getFullYear()} · ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export function formatShortDate(ts) {
+  const d = new Date(ts);
+  return `${pad(d.getDate())} ${MONTHS[d.getMonth()]}`;
+}
+
+export function formatDateRange(startTs, endTs) {
+  const a = new Date(startTs);
+  const b = new Date(endTs);
+  const sameDay =
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();
+  if (sameDay) return `${pad(a.getDate())} ${MONTHS[a.getMonth()]} ${a.getFullYear()}`;
+  if (a.getFullYear() === b.getFullYear()) {
+    if (a.getMonth() === b.getMonth()) {
+      return `${pad(a.getDate())} — ${pad(b.getDate())} ${MONTHS[b.getMonth()]} ${b.getFullYear()}`;
+    }
+    return `${pad(a.getDate())} ${MONTHS[a.getMonth()]} — ${pad(b.getDate())} ${MONTHS[b.getMonth()]} ${b.getFullYear()}`;
+  }
+  return `${pad(a.getDate())} ${MONTHS[a.getMonth()]} ${a.getFullYear()} — ${pad(b.getDate())} ${MONTHS[b.getMonth()]} ${b.getFullYear()}`;
+}
+
+function calendarDay(ts) {
+  const d = new Date(ts);
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+}
+
+export function dayNumber(startTs, ts) {
+  return Math.max(1, Math.round((calendarDay(ts) - calendarDay(startTs)) / DAY_MS));
+}
+
+export function dayTotal(startTs, endTs) {
+  return Math.max(1, Math.round((calendarDay(endTs) - calendarDay(startTs)) / DAY_MS));
+}

--- a/src/utils/videoExport/hudFormat.test.js
+++ b/src/utils/videoExport/hudFormat.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import {
+  dayNumber,
+  dayTotal,
+  formatClockDate,
+  formatDateRange,
+  formatShortDate,
+  splitDistance,
+} from './hudFormat';
+
+const ts = (y, mo, d, h = 0, mi = 0) => new Date(y, mo, d, h, mi).getTime();
+
+describe('splitDistance', () => {
+  it('splits value and unit for the big counter', () => {
+    expect(splitDistance(64820, 'km')).toEqual({ value: '64.8', unit: 'km' });
+    expect(splitDistance(850, 'km')).toEqual({ value: '850', unit: 'm' });
+    expect(splitDistance(12345, 'mi')).toEqual({ value: '7.7', unit: 'mi' });
+  });
+});
+
+describe('clock dates', () => {
+  it('formats the playhead timestamp like the design', () => {
+    expect(formatClockDate(ts(2026, 5, 14, 8, 41))).toBe('14 JUN 2026 · 08:41');
+  });
+
+  it('formats short dates for the progress row', () => {
+    expect(formatShortDate(ts(2026, 5, 8))).toBe('08 JUN');
+  });
+
+  it('collapses date ranges by shared month and year', () => {
+    expect(formatDateRange(ts(2026, 5, 8), ts(2026, 5, 26))).toBe('08 — 26 JUN 2026');
+    expect(formatDateRange(ts(2026, 4, 28), ts(2026, 5, 12))).toBe('28 MAY — 12 JUN 2026');
+    expect(formatDateRange(ts(2025, 11, 28), ts(2026, 0, 3))).toBe('28 DEC 2025 — 03 JAN 2026');
+    expect(formatDateRange(ts(2026, 5, 14), ts(2026, 5, 14))).toBe('14 JUN 2026');
+  });
+});
+
+describe('day counters', () => {
+  it('numbers days the way the design does (start day + 6 → DAY 06)', () => {
+    const start = ts(2026, 5, 8, 9, 30);
+    expect(dayNumber(start, ts(2026, 5, 14, 8, 41))).toBe(6);
+    expect(dayNumber(start, start)).toBe(1);
+    expect(dayTotal(start, ts(2026, 5, 26, 7, 0))).toBe(18);
+    expect(dayTotal(start, start)).toBe(1);
+  });
+});

--- a/src/utils/videoExport/hudOverlay.js
+++ b/src/utils/videoExport/hudOverlay.js
@@ -1,0 +1,239 @@
+// Replay HUD, implementing the "Replay Frames" design: broadcast chrome in
+// the top and bottom safe bands (map clear in the middle third), a progress
+// timeline with the playhead's recorded date, and a summary frame that fades
+// in for the final hold. All sizes derive from the design's 620px reference
+// frame via u = min(width, height) / 100 (design px ÷ 6.2).
+import { hexToRgba } from './colorUtil';
+import {
+  dayNumber,
+  dayTotal,
+  formatClockDate,
+  formatDateRange,
+  formatShortDate,
+  splitDistance,
+} from './hudFormat';
+import { timeAtFraction } from './routeClock';
+
+const MONO = '"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace';
+const SANS = 'Archivo, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, sans-serif';
+const INK = (a) => `rgba(255, 255, 255, ${a})`;
+
+function text(ctx, str, x, y, { font, color, ls = 0, align = 'left', baseline = 'alphabetic' }) {
+  ctx.font = font;
+  ctx.fillStyle = color;
+  ctx.textAlign = align;
+  ctx.textBaseline = baseline;
+  try {
+    ctx.letterSpacing = `${ls}px`;
+  } catch {
+    // Older engines without canvas letterSpacing render slightly tighter.
+  }
+  ctx.fillText(str, x, y);
+  try {
+    ctx.letterSpacing = '0px';
+  } catch {
+    // Same fallback as above.
+  }
+}
+
+function scrim(ctx, width, height, stops, alpha) {
+  const gradient = ctx.createLinearGradient(0, 0, 0, height);
+  for (const [at, a] of stops) gradient.addColorStop(at, `rgba(6, 6, 8, ${a})`);
+  ctx.save();
+  ctx.globalAlpha = alpha;
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  ctx.restore();
+}
+
+function roundedRect(ctx, x, y, w, h, r) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.arcTo(x + w, y, x + w, y + h, r);
+  ctx.arcTo(x + w, y + h, x, y + h, r);
+  ctx.arcTo(x, y + h, x, y, r);
+  ctx.arcTo(x, y, x + w, y, r);
+  ctx.closePath();
+}
+
+function replayChrome(ctx, opts) {
+  const { width, height, u, fraction, distanceM, units, accent, clock, playheadTs } = opts;
+  const inset = u * 3.9;
+
+  if (clock && playheadTs != null) {
+    text(ctx, formatClockDate(playheadTs), inset, inset, {
+      font: `400 ${u * 1.77}px ${MONO}`,
+      color: INK(0.5),
+      ls: u * 1.77 * 0.18,
+      baseline: 'top',
+    });
+    const day = String(dayNumber(clock.startTs, playheadTs)).padStart(2, '0');
+    const total = String(dayTotal(clock.startTs, clock.endTs)).padStart(2, '0');
+    text(ctx, `DAY ${day} / ${total}`, inset, inset + u * 2.6, {
+      font: `400 ${u * 1.77}px ${MONO}`,
+      color: INK(0.34),
+      ls: u * 1.77 * 0.1,
+      baseline: 'top',
+    });
+  }
+
+  const datesBase = height - inset;
+  const trackY = datesBase - u * 1.6 - u * 1.6 - u * 0.48;
+  const numBase = trackY - u * 2.6;
+
+  const dateFont = `400 ${u * 1.6}px ${MONO}`;
+  if (clock) {
+    text(ctx, formatShortDate(clock.startTs), inset, datesBase, {
+      font: dateFont,
+      color: INK(0.34),
+      ls: u * 1.6 * 0.12,
+    });
+    text(ctx, formatShortDate(clock.endTs), width - inset, datesBase, {
+      font: dateFont,
+      color: INK(0.34),
+      ls: u * 1.6 * 0.12,
+      align: 'right',
+    });
+  }
+  text(ctx, 'https://dawarich.app', width / 2, datesBase, {
+    font: dateFont,
+    color: INK(0.5),
+    ls: u * 1.6 * 0.12,
+    align: 'center',
+  });
+
+  const trackW = width - inset * 2;
+  ctx.fillStyle = INK(0.14);
+  roundedRect(ctx, inset, trackY, trackW, u * 0.48, u * 0.24);
+  ctx.fill();
+  if (fraction > 0) {
+    ctx.fillStyle = accent;
+    roundedRect(ctx, inset, trackY, Math.max(u * 0.48, trackW * fraction), u * 0.48, u * 0.24);
+    ctx.fill();
+  }
+  const headX = inset + trackW * fraction;
+  const headY = trackY + u * 0.24;
+  ctx.fillStyle = hexToRgba(accent, 0.35);
+  ctx.beginPath();
+  ctx.arc(headX, headY, u * 0.72 + u * 0.48, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.fillStyle = '#fff';
+  ctx.beginPath();
+  ctx.arc(headX, headY, u * 0.72, 0, Math.PI * 2);
+  ctx.fill();
+
+  text(ctx, 'DISTANCE', inset, numBase - u * 9.2, {
+    font: `400 ${u * 1.6}px ${MONO}`,
+    color: INK(0.42),
+    ls: u * 1.6 * 0.2,
+  });
+  const distance = splitDistance(distanceM, units);
+  text(ctx, distance.value, inset, numBase, {
+    font: `700 ${u * 8.7}px ${MONO}`,
+    color: '#fff',
+    ls: -(u * 8.7 * 0.02),
+  });
+  ctx.font = `700 ${u * 8.7}px ${MONO}`;
+  const numW = ctx.measureText(distance.value).width;
+  text(ctx, distance.unit, inset + numW + u * 1.1, numBase, {
+    font: `500 ${u * 2.9}px ${SANS}`,
+    color: INK(0.55),
+  });
+
+  const valueBase = numBase - u * 1;
+  const labelBase = valueBase - u * 3.2;
+
+  text(ctx, 'OF TOTAL', width - inset, labelBase, {
+    font: `400 ${u * 1.45}px ${MONO}`,
+    color: INK(0.36),
+    ls: u * 1.45 * 0.18,
+    align: 'right',
+  });
+  text(ctx, `${Math.round(fraction * 100)}%`, width - inset, valueBase, {
+    font: `500 ${u * 2.74}px ${MONO}`,
+    color: accent,
+    align: 'right',
+  });
+}
+
+function summaryFrame(ctx, opts) {
+  const { width, height, u, stats, units, accent, clock } = opts;
+  const inset = u * 4.8;
+
+  const footerBase = height - inset;
+  const dividerY = footerBase - u * 2.6 - u * 3.55;
+  const sublineBase = clock ? dividerY - u * 3.55 : dividerY - u * 2.4;
+  const numBase = clock ? sublineBase - u * 5.2 : sublineBase;
+
+  const distance = splitDistance(stats?.distanceM ?? 0, units);
+  if (clock) {
+    text(ctx, formatDateRange(clock.startTs, clock.endTs), inset, numBase - u * 13.4, {
+      font: `400 ${u * 1.77}px ${MONO}`,
+      color: accent,
+      ls: u * 1.77 * 0.22,
+    });
+  }
+  text(ctx, distance.value, inset, numBase, {
+    font: `700 ${u * 14.2}px ${MONO}`,
+    color: '#fff',
+    ls: -(u * 14.2 * 0.03),
+  });
+  ctx.font = `700 ${u * 14.2}px ${MONO}`;
+  const numW = ctx.measureText(distance.value).width;
+  text(ctx, distance.unit, inset + numW + u * 1.6, numBase, {
+    font: `500 ${u * 4.84}px ${SANS}`,
+    color: INK(0.6),
+  });
+  if (clock) {
+    text(ctx, `travelled over ${dayTotal(clock.startTs, clock.endTs)} days`, inset, sublineBase, {
+      font: `500 ${u * 2.74}px ${SANS}`,
+      color: INK(0.62),
+    });
+  }
+
+  ctx.fillStyle = INK(0.13);
+  ctx.fillRect(inset, dividerY, width - inset * 2, 1);
+
+  ctx.fillStyle = accent;
+  ctx.beginPath();
+  ctx.arc(inset + u * 0.72, footerBase - u * 0.8, u * 0.72, 0, Math.PI * 2);
+  ctx.fill();
+  text(ctx, 'https://dawarich.app', inset + u * 2.9, footerBase, {
+    font: `500 ${u * 2.26}px ${SANS}`,
+    color: INK(0.72),
+  });
+  text(ctx, 'PRIVATE LOCATION HISTORY', width - inset, footerBase, {
+    font: `400 ${u * 1.77}px ${MONO}`,
+    color: INK(0.34),
+    ls: u * 1.77 * 0.14,
+    align: 'right',
+  });
+}
+
+export function drawHud(ctx, options) {
+  const { width, height, fraction, outroProgress, clock } = options;
+  const u = Math.min(width, height) / 100;
+  const playheadTs = clock ? timeAtFraction(clock, fraction) : null;
+  const opts = { ...options, u, playheadTs };
+
+  if (outroProgress < 1) {
+    scrim(ctx, width, height, [[0, 0.72], [0.26, 0], [0.52, 0], [1, 0.86]], 1 - outroProgress);
+  }
+  if (outroProgress > 0) {
+    scrim(ctx, width, height, [[0, 0.55], [0.3, 0.25], [0.74, 0.9], [1, 0.97]], outroProgress);
+  }
+
+  ctx.save();
+  if (outroProgress < 1) {
+    ctx.globalAlpha = 1 - outroProgress;
+    replayChrome(ctx, opts);
+  }
+  ctx.restore();
+
+  ctx.save();
+  if (outroProgress > 0) {
+    ctx.globalAlpha = outroProgress;
+    summaryFrame(ctx, opts);
+  }
+  ctx.restore();
+}

--- a/src/utils/videoExport/mp4Encoder.js
+++ b/src/utils/videoExport/mp4Encoder.js
@@ -1,0 +1,78 @@
+// WebCodecs → mp4-muxer wrapper. Encodes composited canvas frames into an
+// in-memory MP4. Browser-only: callers gate on isVideoExportSupported().
+import { ArrayBufferTarget, Muxer } from 'mp4-muxer';
+import { pickSupportedCodec } from './codecNegotiation';
+
+const KEYFRAME_INTERVAL_SEC = 2;
+const MAX_ENCODE_QUEUE = 8;
+
+export function isVideoExportSupported() {
+  return typeof VideoEncoder === 'function' && typeof VideoFrame === 'function';
+}
+
+export async function createMp4Encoder({ width, height, fps }) {
+  if (!isVideoExportSupported()) return null;
+
+  const picked = await pickSupportedCodec({
+    width,
+    height,
+    fps,
+    isConfigSupported: (config) => VideoEncoder.isConfigSupported(config),
+  });
+  if (!picked) return null;
+
+  const target = new ArrayBufferTarget();
+  const muxer = new Muxer({
+    target,
+    video: { codec: picked.muxerCodec, width, height, frameRate: fps },
+    fastStart: 'in-memory',
+    firstTimestampBehavior: 'offset',
+  });
+
+  let encodeError = null;
+  const encoder = new VideoEncoder({
+    output: (chunk, meta) => muxer.addVideoChunk(chunk, meta),
+    error: (error) => {
+      encodeError = error;
+    },
+  });
+  encoder.configure(picked.config);
+
+  const keyframeEvery = Math.max(1, Math.round(fps * KEYFRAME_INTERVAL_SEC));
+  const frameMicros = Math.round(1e6 / fps);
+
+  return {
+    codec: picked.config.codec,
+
+    async addFrame(canvas, frameIndex) {
+      if (encodeError) throw encodeError;
+      const frame = new VideoFrame(canvas, {
+        timestamp: frameIndex * frameMicros,
+        duration: frameMicros,
+      });
+      encoder.encode(frame, { keyFrame: frameIndex % keyframeEvery === 0 });
+      frame.close();
+      while (encoder.encodeQueueSize > MAX_ENCODE_QUEUE && !encodeError) {
+        await new Promise((resolve) => {
+          encoder.addEventListener('dequeue', resolve, { once: true });
+        });
+      }
+    },
+
+    async finalize() {
+      await encoder.flush();
+      encoder.close();
+      if (encodeError) throw encodeError;
+      muxer.finalize();
+      return new Blob([target.buffer], { type: 'video/mp4' });
+    },
+
+    abort() {
+      try {
+        if (encoder.state !== 'closed') encoder.close();
+      } catch {
+        // Already closed while tearing down — nothing to release.
+      }
+    },
+  };
+}

--- a/src/utils/videoExport/pathSmoothing.js
+++ b/src/utils/videoExport/pathSmoothing.js
@@ -1,0 +1,54 @@
+// Bounded Chaikin corner-cutting for GPS polylines: sharp vertices become
+// short arcs so the head marker steers through corners instead of pivoting.
+// The cut distance is capped in meters, so sparse tracks keep their shape
+// (a 1 km leg is not redrawn 250 m early), and vertices whose edges are
+// already shorter than a video pixel pass through untouched.
+import { haversineDistance } from '../geo';
+
+const DEFAULT_ITERATIONS = 2;
+const DEFAULT_MAX_CORNER_M = 30;
+const DEFAULT_MIN_EDGE_M = 12;
+
+function edgeMeters(a, b) {
+  return haversineDistance(a[1], a[0], b[1], b[0]);
+}
+
+function towards(from, to, t) {
+  return [from[0] + (to[0] - from[0]) * t, from[1] + (to[1] - from[1]) * t];
+}
+
+function cutRatio(edgeLen, maxCornerM) {
+  return edgeLen > 0 ? Math.min(0.25, maxCornerM / edgeLen) : 0;
+}
+
+export function smoothSegmentCoords(
+  coords,
+  {
+    iterations = DEFAULT_ITERATIONS,
+    maxCornerM = DEFAULT_MAX_CORNER_M,
+    minEdgeM = DEFAULT_MIN_EDGE_M,
+  } = {},
+) {
+  if (!Array.isArray(coords) || coords.length < 3) return coords;
+
+  let current = coords;
+  for (let round = 0; round < iterations; round += 1) {
+    const out = [current[0]];
+    for (let i = 1; i < current.length - 1; i += 1) {
+      const vertex = current[i];
+      const prev = current[i - 1];
+      const next = current[i + 1];
+      const lenPrev = edgeMeters(prev, vertex);
+      const lenNext = edgeMeters(vertex, next);
+      if (lenPrev < minEdgeM && lenNext < minEdgeM) {
+        out.push(vertex);
+      } else {
+        out.push(towards(vertex, prev, cutRatio(lenPrev, maxCornerM)));
+        out.push(towards(vertex, next, cutRatio(lenNext, maxCornerM)));
+      }
+    }
+    out.push(current[current.length - 1]);
+    current = out;
+  }
+  return current;
+}

--- a/src/utils/videoExport/pathSmoothing.test.js
+++ b/src/utils/videoExport/pathSmoothing.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { haversineDistance } from '../geo';
+import { smoothSegmentCoords } from './pathSmoothing';
+
+// ~90° corner with two ~1.1 km legs at the equator.
+const SHARP_CORNER = [
+  [0, 0],
+  [0.01, 0],
+  [0.01, 0.01],
+];
+
+describe('smoothSegmentCoords', () => {
+  it('preserves the endpoints exactly', () => {
+    const out = smoothSegmentCoords(SHARP_CORNER);
+    expect(out[0]).toEqual([0, 0]);
+    expect(out[out.length - 1]).toEqual([0.01, 0.01]);
+  });
+
+  it('replaces a sharp corner with an arc of nearby points', () => {
+    const out = smoothSegmentCoords(SHARP_CORNER, { maxCornerM: 30 });
+    expect(out.length).toBeGreaterThan(SHARP_CORNER.length);
+    expect(out.some(([lon, lat]) => lon === 0.01 && lat === 0)).toBe(false);
+    // Every new point hugs the corner: within ~2× the corner radius of the
+    // original vertex, never a quarter of the way down a 1.1 km leg.
+    for (const [lon, lat] of out.slice(1, -1)) {
+      expect(haversineDistance(0, 0.01, lat, lon)).toBeLessThan(65);
+    }
+  });
+
+  it('keeps collinear input on its line', () => {
+    const straight = [
+      [13.4, 52.5],
+      [13.41, 52.5],
+      [13.42, 52.5],
+    ];
+    for (const [, lat] of smoothSegmentCoords(straight)) {
+      expect(lat).toBeCloseTo(52.5, 9);
+    }
+  });
+
+  it('passes dense recordings through unchanged', () => {
+    // Edges of ~5.6 m — already smooth at any video zoom.
+    const dense = [0, 1, 2, 3].map((i) => [i * 0.00005, 0]);
+    expect(smoothSegmentCoords(dense, { minEdgeM: 12 })).toEqual(dense);
+  });
+
+  it('returns short or degenerate input as-is', () => {
+    expect(smoothSegmentCoords([[1, 1]])).toEqual([[1, 1]]);
+    const two = [
+      [0, 0],
+      [1, 1],
+    ];
+    expect(smoothSegmentCoords(two)).toEqual(two);
+    const withDuplicate = [
+      [0, 0],
+      [0, 0],
+      [0.01, 0],
+    ];
+    for (const coord of smoothSegmentCoords(withDuplicate)) {
+      expect(Number.isFinite(coord[0])).toBe(true);
+      expect(Number.isFinite(coord[1])).toBe(true);
+    }
+  });
+});

--- a/src/utils/videoExport/renderPlan.js
+++ b/src/utils/videoExport/renderPlan.js
@@ -1,0 +1,37 @@
+// Frame schedule for a render: a hold on the empty map, an eased draw phase,
+// and a hold on the finished route for the stats card.
+const DEFAULT_INTRO_HOLD_SEC = 0.6;
+const DEFAULT_OUTRO_HOLD_SEC = 3;
+
+function easeInOutSine(t) {
+  return (1 - Math.cos(Math.PI * t)) / 2;
+}
+
+export function buildRenderPlan({
+  durationSec,
+  fps = 30,
+  introHoldSec = DEFAULT_INTRO_HOLD_SEC,
+  outroHoldSec = DEFAULT_OUTRO_HOLD_SEC,
+}) {
+  const totalFrames = Math.max(1, Math.round(durationSec * fps));
+  let introFrames = Math.round(introHoldSec * fps);
+  let outroFrames = Math.round(outroHoldSec * fps);
+
+  const holdFrames = introFrames + outroFrames;
+  if (holdFrames >= totalFrames) {
+    const scale = (totalFrames - 1) / holdFrames;
+    introFrames = Math.floor(introFrames * scale);
+    outroFrames = Math.floor(outroFrames * scale);
+  }
+
+  return { fps, totalFrames, introFrames, outroFrames };
+}
+
+export function frameFraction(plan, frameIndex) {
+  const { totalFrames, introFrames, outroFrames } = plan;
+  const i = Math.max(0, Math.min(totalFrames - 1, frameIndex));
+  const drawFrames = totalFrames - introFrames - outroFrames;
+  if (i < introFrames) return 0;
+  if (i >= totalFrames - outroFrames) return 1;
+  return easeInOutSine((i - introFrames) / drawFrames);
+}

--- a/src/utils/videoExport/renderPlan.test.js
+++ b/src/utils/videoExport/renderPlan.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { buildRenderPlan, frameFraction } from './renderPlan';
+
+describe('buildRenderPlan', () => {
+  it('derives frame counts from duration and fps', () => {
+    const plan = buildRenderPlan({ durationSec: 15, fps: 30 });
+    expect(plan.totalFrames).toBe(450);
+    expect(plan.fps).toBe(30);
+    expect(plan.introFrames + plan.outroFrames).toBeLessThan(plan.totalFrames);
+  });
+
+  it('holds the summary frame for the last three seconds by default', () => {
+    const plan = buildRenderPlan({ durationSec: 15, fps: 30 });
+    expect(plan.outroFrames).toBe(90);
+  });
+
+  it('shrinks the holds when the video is too short to fit them', () => {
+    const plan = buildRenderPlan({ durationSec: 1, fps: 30, introHoldSec: 0.6, outroHoldSec: 1.8 });
+    expect(plan.totalFrames).toBe(30);
+    expect(plan.introFrames + plan.outroFrames).toBeLessThan(30);
+    expect(frameFraction(plan, 29)).toBe(1);
+  });
+});
+
+describe('frameFraction', () => {
+  const plan = buildRenderPlan({ durationSec: 15, fps: 30, introHoldSec: 1, outroHoldSec: 2 });
+
+  it('holds at zero through the intro', () => {
+    expect(frameFraction(plan, 0)).toBe(0);
+    expect(frameFraction(plan, plan.introFrames - 1)).toBe(0);
+  });
+
+  it('holds at one through the outro and the final frame', () => {
+    expect(frameFraction(plan, plan.totalFrames - plan.outroFrames)).toBe(1);
+    expect(frameFraction(plan, plan.totalFrames - 1)).toBe(1);
+  });
+
+  it('reaches one half at the middle of the draw phase', () => {
+    const drawFrames = plan.totalFrames - plan.introFrames - plan.outroFrames;
+    const mid = plan.introFrames + drawFrames / 2;
+    expect(frameFraction(plan, mid)).toBeCloseTo(0.5, 5);
+  });
+
+  it('never decreases from one frame to the next', () => {
+    let last = -1;
+    for (let i = 0; i < plan.totalFrames; i += 1) {
+      const f = frameFraction(plan, i);
+      expect(f).toBeGreaterThanOrEqual(last);
+      last = f;
+    }
+  });
+
+  it('clamps frame indexes outside the plan', () => {
+    expect(frameFraction(plan, -5)).toBe(0);
+    expect(frameFraction(plan, plan.totalFrames + 5)).toBe(1);
+  });
+});

--- a/src/utils/videoExport/routeClock.js
+++ b/src/utils/videoExport/routeClock.js
@@ -1,0 +1,62 @@
+// Maps distance along the route to recorded time, so the HUD can show the
+// playhead's date, clock time, and elapsed span. Uses the same gap rule as
+// the drawn track: pairs separated by more than the threshold advance time
+// but not distance, mirroring the segment jumps that cost no animation time.
+import { haversineDistance } from '../geo';
+
+const DEFAULT_GAP_MINUTES = 60;
+
+function isValidTimedPoint(point) {
+  return (
+    point != null &&
+    Number.isFinite(point.lat) &&
+    Number.isFinite(point.lon) &&
+    Math.abs(point.lat) <= 90 &&
+    Math.abs(point.lon) <= 180 &&
+    point.time != null &&
+    !Number.isNaN(Date.parse(point.time))
+  );
+}
+
+export function buildRouteClock(points, { gapMinutes = DEFAULT_GAP_MINUTES } = {}) {
+  const timed = (Array.isArray(points) ? points : [])
+    .filter(isValidTimedPoint)
+    .map((point) => ({ ...point, ts: Date.parse(point.time) }))
+    .sort((a, b) => a.ts - b.ts);
+  if (timed.length < 2) return null;
+
+  const gapMs = gapMinutes * 60 * 1000;
+  const entries = [{ dist: 0, ts: timed[0].ts }];
+  let dist = 0;
+  for (let i = 1; i < timed.length; i += 1) {
+    const prev = timed[i - 1];
+    const point = timed[i];
+    if (point.ts - prev.ts <= gapMs) {
+      dist += haversineDistance(prev.lat, prev.lon, point.lat, point.lon);
+    }
+    entries.push({ dist, ts: point.ts });
+  }
+
+  return {
+    entries,
+    totalDistance: dist,
+    startTs: entries[0].ts,
+    endTs: entries[entries.length - 1].ts,
+  };
+}
+
+export function timeAtFraction(clock, fraction) {
+  const { entries, totalDistance } = clock;
+  const f = Math.max(0, Math.min(1, fraction));
+  const target = f * totalDistance;
+
+  for (let i = 1; i < entries.length; i += 1) {
+    if (entries[i].dist >= target) {
+      const prev = entries[i - 1];
+      const span = entries[i].dist - prev.dist;
+      const t = span > 0 ? (target - prev.dist) / span : 0;
+      return Math.round(prev.ts + (entries[i].ts - prev.ts) * t);
+    }
+  }
+  return clock.endTs;
+}

--- a/src/utils/videoExport/routeClock.test.js
+++ b/src/utils/videoExport/routeClock.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { buildRouteClock, timeAtFraction } from './routeClock';
+
+// Local-time constructors keep the tests timezone-independent.
+const t = (h, m) => new Date(2026, 5, 14, h, m).toISOString();
+
+const timedPoints = [
+  { lat: 52.5, lon: 13.4, time: t(8, 0) },
+  { lat: 52.5, lon: 13.41, time: t(8, 30) },
+  { lat: 52.5, lon: 13.42, time: t(9, 0) },
+];
+
+describe('buildRouteClock', () => {
+  it('maps cumulative distance to recorded timestamps', () => {
+    const clock = buildRouteClock(timedPoints);
+    expect(clock.startTs).toBe(new Date(2026, 5, 14, 8, 0).getTime());
+    expect(clock.endTs).toBe(new Date(2026, 5, 14, 9, 0).getTime());
+    expect(clock.totalDistance).toBeGreaterThan(1300);
+    expect(clock.entries).toHaveLength(3);
+  });
+
+  it('plateaus distance across a long gap while time jumps', () => {
+    const gapped = [
+      { lat: 52.5, lon: 13.4, time: t(8, 0) },
+      { lat: 52.5, lon: 13.41, time: t(8, 30) },
+      { lat: 52.6, lon: 13.6, time: t(14, 0) },
+      { lat: 52.6, lon: 13.61, time: t(14, 30) },
+    ];
+    const clock = buildRouteClock(gapped);
+    expect(clock.entries[2].dist).toBe(clock.entries[1].dist);
+    expect(clock.entries[2].ts).toBe(new Date(2026, 5, 14, 14, 0).getTime());
+  });
+
+  it('returns null without at least two timed points', () => {
+    expect(buildRouteClock([{ lat: 52.5, lon: 13.4 }])).toBeNull();
+    expect(buildRouteClock([{ lat: 52.5, lon: 13.4, time: t(8, 0) }])).toBeNull();
+    expect(buildRouteClock([])).toBeNull();
+  });
+});
+
+describe('timeAtFraction', () => {
+  const clock = buildRouteClock(timedPoints);
+
+  it('interpolates the playhead time along the distance', () => {
+    expect(timeAtFraction(clock, 0)).toBe(new Date(2026, 5, 14, 8, 0).getTime());
+    expect(timeAtFraction(clock, 1)).toBe(new Date(2026, 5, 14, 9, 0).getTime());
+    const mid = timeAtFraction(clock, 0.5);
+    expect(mid).toBeGreaterThan(new Date(2026, 5, 14, 8, 25).getTime());
+    expect(mid).toBeLessThan(new Date(2026, 5, 14, 8, 35).getTime());
+  });
+
+  it('clamps fractions outside 0..1', () => {
+    expect(timeAtFraction(clock, -1)).toBe(clock.startTs);
+    expect(timeAtFraction(clock, 2)).toBe(clock.endTs);
+  });
+});

--- a/src/utils/videoExport/routeTimeline.js
+++ b/src/utils/videoExport/routeTimeline.js
@@ -1,0 +1,114 @@
+// Distance-paced animation timeline for a track FeatureCollection (the
+// posterTrack shape: LineString segments split on time gaps, stray Points).
+// The route draws at constant speed along its own length; jumps between
+// disjoint segments cost no animation time.
+import { haversineDistance } from '../geo';
+import { smoothSegmentCoords } from './pathSmoothing';
+
+export function buildRouteTimeline(trackGeojson, { smooth = false } = {}) {
+  const entries = [];
+  let totalDistance = 0;
+  const features = trackGeojson?.features ?? [];
+  let seg = 0;
+  for (const feature of features) {
+    const geometry = feature?.geometry;
+    if (!geometry || geometry.type !== 'LineString') continue;
+    let coordinates = geometry.coordinates ?? [];
+    if (coordinates.length < 2) continue;
+    if (smooth) coordinates = smoothSegmentCoords(coordinates);
+    for (let i = 0; i < coordinates.length; i += 1) {
+      const coord = coordinates[i];
+      if (i > 0) {
+        const prev = coordinates[i - 1];
+        totalDistance += haversineDistance(prev[1], prev[0], coord[1], coord[0]);
+      }
+      entries.push({ coord, dist: totalDistance, seg });
+    }
+    seg += 1;
+  }
+  return { entries, totalDistance };
+}
+
+function lerpCoord(a, b, t) {
+  return [a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t];
+}
+
+function lineFeature(coordinates) {
+  return {
+    type: 'Feature',
+    properties: {},
+    geometry: { type: 'LineString', coordinates },
+  };
+}
+
+// The sub-path between two distances along the route — the "fresh" window
+// that stays at full brightness behind the pen while older stretches dim.
+export function sliceWindow(timeline, fromDist, toDist) {
+  const { entries, totalDistance } = timeline;
+  if (entries.length === 0) return { features: [] };
+  const from = Math.max(0, Math.min(totalDistance, fromDist));
+  const to = Math.max(from, Math.min(totalDistance, toDist));
+  if (to <= from) return { features: [] };
+
+  const features = [];
+  let current = [];
+  for (let i = 1; i < entries.length; i += 1) {
+    const prev = entries[i - 1];
+    const entry = entries[i];
+    if (prev.seg !== entry.seg) {
+      if (current.length >= 2) features.push(lineFeature(current));
+      current = [];
+      continue;
+    }
+    const start = Math.max(prev.dist, from);
+    const end = Math.min(entry.dist, to);
+    const span = entry.dist - prev.dist;
+    if (end <= start || span <= 0) continue;
+    if (current.length === 0) {
+      current.push(lerpCoord(prev.coord, entry.coord, (start - prev.dist) / span));
+    }
+    current.push(lerpCoord(prev.coord, entry.coord, (end - prev.dist) / span));
+  }
+  if (current.length >= 2) features.push(lineFeature(current));
+  return { features };
+}
+
+export function sliceAtFraction(timeline, fraction) {
+  const { entries, totalDistance } = timeline;
+  if (entries.length === 0) return { features: [], head: null, distance: 0 };
+
+  const f = Math.max(0, Math.min(1, fraction));
+  const target = f * totalDistance;
+
+  const features = [];
+  let current = [];
+  let head = entries[0].coord;
+  let done = false;
+
+  for (let i = 0; i < entries.length && !done; i += 1) {
+    const entry = entries[i];
+    const isNewSegment = current.length > 0 && entry.seg !== entries[i - 1].seg;
+    if (isNewSegment) {
+      if (current.length >= 2) features.push(lineFeature(current));
+      current = [];
+    }
+    if (entry.dist <= target) {
+      current.push(entry.coord);
+      head = entry.coord;
+    } else {
+      const prev = entries[i - 1];
+      if (prev && prev.seg === entry.seg) {
+        const span = entry.dist - prev.dist;
+        const t = span > 0 ? (target - prev.dist) / span : 0;
+        if (t > 0) {
+          head = lerpCoord(prev.coord, entry.coord, t);
+          current.push(head);
+        }
+      }
+      done = true;
+    }
+  }
+  if (current.length >= 2) features.push(lineFeature(current));
+
+  return { features, head, distance: target };
+}

--- a/src/utils/videoExport/routeTimeline.test.js
+++ b/src/utils/videoExport/routeTimeline.test.js
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import { buildRouteTimeline, sliceAtFraction, sliceWindow } from './routeTimeline';
+
+// Two eastward steps of 0.01° longitude at 52.5°N ≈ 677.6 m each.
+const STRAIGHT_LINE = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      properties: {},
+      geometry: {
+        type: 'LineString',
+        coordinates: [
+          [13.4, 52.5],
+          [13.41, 52.5],
+          [13.42, 52.5],
+        ],
+      },
+    },
+  ],
+};
+
+const TWO_SEGMENTS = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      properties: {},
+      geometry: {
+        type: 'LineString',
+        coordinates: [
+          [13.4, 52.5],
+          [13.41, 52.5],
+        ],
+      },
+    },
+    {
+      type: 'Feature',
+      properties: {},
+      geometry: {
+        type: 'LineString',
+        coordinates: [
+          [13.6, 52.6],
+          [13.61, 52.6],
+        ],
+      },
+    },
+  ],
+};
+
+describe('buildRouteTimeline', () => {
+  it('accumulates haversine distance along a line', () => {
+    const timeline = buildRouteTimeline(STRAIGHT_LINE);
+    expect(timeline.totalDistance).toBeCloseTo(1355, -1);
+    expect(timeline.entries).toHaveLength(3);
+    expect(timeline.entries[0].dist).toBe(0);
+    expect(timeline.entries[2].dist).toBeCloseTo(timeline.totalDistance, 5);
+  });
+
+  it('does not count the jump between disjoint segments as distance', () => {
+    const timeline = buildRouteTimeline(TWO_SEGMENTS);
+    // Two segments of one ~677.6 m step each; the ~25 km gap contributes nothing.
+    expect(timeline.totalDistance).toBeCloseTo(2 * 677.6, -1);
+    expect(timeline.entries[2].dist).toBe(timeline.entries[1].dist);
+    expect(timeline.entries[1].seg).toBe(0);
+    expect(timeline.entries[2].seg).toBe(1);
+  });
+
+  it('rounds sharp corners when smoothing is enabled', () => {
+    const cornered = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'LineString',
+            coordinates: [
+              [13.4, 52.5],
+              [13.41, 52.5],
+              [13.41, 52.51],
+            ],
+          },
+        },
+      ],
+    };
+    const raw = buildRouteTimeline(cornered);
+    const smoothed = buildRouteTimeline(cornered, { smooth: true });
+    expect(smoothed.entries.length).toBeGreaterThan(raw.entries.length);
+    expect(smoothed.entries.some((e) => e.coord[0] === 13.41 && e.coord[1] === 52.5)).toBe(false);
+    expect(smoothed.totalDistance).toBeLessThan(raw.totalDistance);
+    expect(smoothed.totalDistance).toBeGreaterThan(raw.totalDistance * 0.97);
+  });
+
+  it('ignores Point features and handles empty input', () => {
+    const withPoint = {
+      type: 'FeatureCollection',
+      features: [
+        { type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [13.4, 52.5] } },
+      ],
+    };
+    expect(buildRouteTimeline(withPoint).totalDistance).toBe(0);
+    expect(buildRouteTimeline(null).entries).toHaveLength(0);
+  });
+});
+
+describe('sliceAtFraction', () => {
+  it('returns the interpolated head at the midpoint of a straight line', () => {
+    const timeline = buildRouteTimeline(STRAIGHT_LINE);
+    const slice = sliceAtFraction(timeline, 0.5);
+    expect(slice.head[0]).toBeCloseTo(13.41, 3);
+    expect(slice.head[1]).toBeCloseTo(52.5, 5);
+    expect(slice.features).toHaveLength(1);
+    const coords = slice.features[0].geometry.coordinates;
+    expect(coords[0]).toEqual([13.4, 52.5]);
+    expect(coords[coords.length - 1][0]).toBeCloseTo(13.41, 3);
+  });
+
+  it('emits the finished segment whole plus a partial second segment', () => {
+    const timeline = buildRouteTimeline(TWO_SEGMENTS);
+    const slice = sliceAtFraction(timeline, 0.75);
+    expect(slice.features).toHaveLength(2);
+    expect(slice.features[0].geometry.coordinates).toHaveLength(2);
+    const partial = slice.features[1].geometry.coordinates;
+    expect(partial[partial.length - 1][0]).toBeCloseTo(13.605, 3);
+    expect(slice.head[1]).toBeCloseTo(52.6, 5);
+  });
+
+  it('clamps fractions outside 0..1', () => {
+    const timeline = buildRouteTimeline(STRAIGHT_LINE);
+    expect(sliceAtFraction(timeline, -1).features).toHaveLength(0);
+    expect(sliceAtFraction(timeline, -1).head).toEqual([13.4, 52.5]);
+    const full = sliceAtFraction(timeline, 2);
+    expect(full.features[0].geometry.coordinates).toHaveLength(3);
+    expect(full.head[0]).toBeCloseTo(13.42, 6);
+  });
+
+  it('returns an empty slice for an empty timeline', () => {
+    const timeline = buildRouteTimeline(null);
+    const slice = sliceAtFraction(timeline, 0.5);
+    expect(slice.features).toHaveLength(0);
+    expect(slice.head).toBeNull();
+  });
+});
+
+describe('sliceWindow', () => {
+  it('returns the sub-path between two distances with interpolated ends', () => {
+    const timeline = buildRouteTimeline(STRAIGHT_LINE);
+    const window = sliceWindow(timeline, timeline.totalDistance * 0.25, timeline.totalDistance * 0.75);
+    expect(window.features).toHaveLength(1);
+    const coords = window.features[0].geometry.coordinates;
+    expect(coords[0][0]).toBeCloseTo(13.405, 3);
+    expect(coords[coords.length - 1][0]).toBeCloseTo(13.415, 3);
+  });
+
+  it('spans a segment gap as two features', () => {
+    const timeline = buildRouteTimeline(TWO_SEGMENTS);
+    const window = sliceWindow(timeline, timeline.totalDistance * 0.25, timeline.totalDistance * 0.75);
+    expect(window.features).toHaveLength(2);
+  });
+
+  it('clamps to the route and returns empty for an empty window', () => {
+    const timeline = buildRouteTimeline(STRAIGHT_LINE);
+    const full = sliceWindow(timeline, -100, timeline.totalDistance + 100);
+    expect(full.features[0].geometry.coordinates).toHaveLength(3);
+    expect(sliceWindow(timeline, 500, 500).features).toHaveLength(0);
+    expect(sliceWindow(buildRouteTimeline(null), 0, 100).features).toHaveLength(0);
+  });
+});

--- a/src/utils/videoExport/videoRenderer.js
+++ b/src/utils/videoExport/videoRenderer.js
@@ -1,0 +1,248 @@
+// Renders the route replay into an MP4, entirely in the browser: a hidden
+// MapLibre map is driven frame by frame (partial track via setData, camera
+// via jumpTo), each settled frame is composited with the HUD onto a canvas
+// and handed to the WebCodecs encoder.
+import maplibregl from 'maplibre-gl';
+import { TRACK_SOURCE_ID } from '../../lib/poster-studio/render/style_builder';
+import { trackBounds } from '../../lib/poster-studio/ui/preview';
+import { followCenter, lerpCamera } from './cameraPath';
+import { DAWARICH_BLUE, hexToRgba } from './colorUtil';
+import { ensureHudFonts } from './hudFonts';
+import { drawHud } from './hudOverlay';
+import { createMp4Encoder } from './mp4Encoder';
+import { buildRenderPlan, frameFraction } from './renderPlan';
+import { buildRouteClock } from './routeClock';
+import { buildRouteTimeline, sliceAtFraction, sliceWindow } from './routeTimeline';
+
+const HEAD_SOURCE_ID = 'video-head';
+const FRESH_SOURCE_ID = 'video-fresh';
+const EMPTY_FC = { type: 'FeatureCollection', features: [] };
+const IDLE_TIMEOUT_MS = 400;
+const OUTRO_FADE_FRAMES = 12;
+const FIT_PADDING_CSS_PX = 40;
+
+// Recency fade: the whole drawn route stays as a dim base while the last
+// stretch behind the pen renders at full brightness with a fade-in tail.
+const FRESH_WINDOW_FRACTION = 0.22;
+const DIM_TRACK_OPACITY = 0.38;
+const DIM_CASING_FACTOR = 0.5;
+
+// Summary pull-out: ease the camera to a view slightly wider than the fit.
+const PULL_SECONDS = 1.4;
+const ZOOM_OUT_DELTA = 0.8;
+
+function easeInOutCubic(t) {
+  return t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2;
+}
+
+function headFC(head) {
+  if (!head) return EMPTY_FC;
+  return {
+    type: 'FeatureCollection',
+    features: [
+      { type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: head } },
+    ],
+  };
+}
+
+function styleForVideo(style, accent) {
+  const prepared = JSON.parse(JSON.stringify(style));
+  prepared.sources[TRACK_SOURCE_ID].data = EMPTY_FC;
+  prepared.sources[HEAD_SOURCE_ID] = { type: 'geojson', data: EMPTY_FC };
+  prepared.sources[FRESH_SOURCE_ID] = { type: 'geojson', data: EMPTY_FC, lineMetrics: true };
+
+  const track = prepared.layers.find((layer) => layer.id === 'poster_track');
+  const casing = prepared.layers.find((layer) => layer.id === 'poster_track_casing');
+  const baseOpacity =
+    typeof track?.paint?.['line-opacity'] === 'number' ? track.paint['line-opacity'] : 1;
+  if (casing) {
+    const casingOpacity =
+      typeof casing.paint?.['line-opacity'] === 'number' ? casing.paint['line-opacity'] : 1;
+    casing.paint['line-opacity'] = casingOpacity * DIM_CASING_FACTOR;
+  }
+  if (track) {
+    track.paint['line-opacity'] = baseOpacity * DIM_TRACK_OPACITY;
+    const fresh = JSON.parse(JSON.stringify(track));
+    fresh.id = 'video_fresh';
+    fresh.source = FRESH_SOURCE_ID;
+    fresh.paint['line-opacity'] = baseOpacity;
+    fresh.paint['line-gradient'] = [
+      'interpolate',
+      ['linear'],
+      ['line-progress'],
+      0,
+      hexToRgba(accent, 0),
+      0.35,
+      hexToRgba(accent, 0.45),
+      1,
+      hexToRgba(accent, 1),
+    ];
+    prepared.layers.push(fresh);
+  }
+
+  prepared.layers.push(
+    {
+      id: 'video_head_ring',
+      type: 'circle',
+      source: HEAD_SOURCE_ID,
+      paint: { 'circle-radius': 9, 'circle-color': '#ffffff' },
+    },
+    {
+      id: 'video_head_dot',
+      type: 'circle',
+      source: HEAD_SOURCE_ID,
+      paint: { 'circle-radius': 6, 'circle-color': accent },
+    },
+  );
+  return prepared;
+}
+
+function nextIdle(map) {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      map.off('idle', onIdle);
+      resolve();
+    }, IDLE_TIMEOUT_MS);
+    const onIdle = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    map.once('idle', onIdle);
+    map.triggerRepaint();
+  });
+}
+
+function throwIfAborted(signal) {
+  if (signal?.aborted) throw new Error('Render cancelled');
+}
+
+export async function renderRouteVideo({
+  style,
+  trackGeojson,
+  points,
+  stats,
+  width,
+  height,
+  fps = 30,
+  durationSec,
+  cameraMode = 'overview',
+  followZoom = 13.5,
+  accent = DAWARICH_BLUE,
+  units = 'km',
+  onProgress,
+  signal,
+}) {
+  const encoder = await createMp4Encoder({ width, height, fps });
+  if (!encoder) {
+    throw new Error(
+      'This browser cannot encode video. Try a current version of Chrome, Edge, Safari, or Firefox.',
+    );
+  }
+
+  const timeline = buildRouteTimeline(trackGeojson, { smooth: true });
+  const clock = buildRouteClock(points);
+  const plan = buildRenderPlan({ durationSec, fps });
+  await ensureHudFonts();
+  const cssWidth = Math.round(width / 2);
+  const cssHeight = Math.round(height / 2);
+
+  const container = document.createElement('div');
+  container.style.cssText = `position:fixed;left:-99999px;top:0;width:${cssWidth}px;height:${cssHeight}px;pointer-events:none;`;
+  document.body.appendChild(container);
+
+  const bounds = trackBounds(trackGeojson);
+  const follow = cameraMode === 'follow' && timeline.entries.length > 0;
+  const map = new maplibregl.Map({
+    container,
+    style: styleForVideo(style, accent),
+    ...(follow
+      ? { center: followCenter(timeline, 0), zoom: followZoom }
+      : bounds
+        ? { bounds, fitBoundsOptions: { padding: FIT_PADDING_CSS_PX, animate: false } }
+        : { center: [0, 0], zoom: 1 }),
+    interactive: false,
+    attributionControl: false,
+    preserveDrawingBuffer: true,
+    fadeDuration: 0,
+    pixelRatio: width / cssWidth,
+  });
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+
+  try {
+    await new Promise((resolve, reject) => {
+      map.once('idle', resolve);
+      map.once('error', (event) => reject(event.error ?? new Error('Map failed to load')));
+    });
+
+    const outroStart = plan.totalFrames - plan.outroFrames;
+    const pullFrames = Math.min(plan.outroFrames, Math.round(PULL_SECONDS * fps));
+    const fit = bounds ? map.cameraForBounds(bounds, { padding: FIT_PADDING_CSS_PX }) : null;
+    const pullTo = fit
+      ? { center: [fit.center.lng, fit.center.lat], zoom: fit.zoom - ZOOM_OUT_DELTA }
+      : null;
+    let pullFrom = null;
+    let lastFraction = -1;
+
+    for (let i = 0; i < plan.totalFrames; i += 1) {
+      throwIfAborted(signal);
+
+      const fraction = frameFraction(plan, i);
+      const slice = sliceAtFraction(timeline, fraction);
+      if (fraction !== lastFraction) {
+        const target = fraction * timeline.totalDistance;
+        const freshWindow = sliceWindow(
+          timeline,
+          target - timeline.totalDistance * FRESH_WINDOW_FRACTION,
+          target,
+        );
+        map.getSource(TRACK_SOURCE_ID).setData({ type: 'FeatureCollection', features: slice.features });
+        map.getSource(FRESH_SOURCE_ID).setData({ type: 'FeatureCollection', features: freshWindow.features });
+        map.getSource(HEAD_SOURCE_ID).setData(headFC(fraction < 1 ? slice.head : null));
+        if (follow) map.jumpTo({ center: followCenter(timeline, fraction), zoom: followZoom });
+        lastFraction = fraction;
+      }
+      if (i >= outroStart && pullTo) {
+        if (!pullFrom) {
+          const center = map.getCenter();
+          pullFrom = { center: [center.lng, center.lat], zoom: map.getZoom() };
+        }
+        const eased = easeInOutCubic(Math.min(1, (i - outroStart + 1) / pullFrames));
+        const camera = lerpCamera(pullFrom, pullTo, eased);
+        map.jumpTo({ center: camera.center, zoom: camera.zoom });
+      }
+      await nextIdle(map);
+
+      ctx.drawImage(map.getCanvas(), 0, 0, width, height);
+      drawHud(ctx, {
+        width,
+        height,
+        fraction,
+        outroProgress: i >= outroStart ? Math.min(1, (i - outroStart + 1) / OUTRO_FADE_FRAMES) : 0,
+        // The smoothed path is slightly shorter than the recorded track, so
+        // the live counter scales the real distance rather than measuring the
+        // drawn line — it always lands exactly on the summary's total.
+        distanceM: fraction * (stats?.distanceM ?? timeline.totalDistance),
+        stats,
+        units,
+        accent,
+        clock,
+      });
+
+      await encoder.addFrame(canvas, i);
+      onProgress?.(i + 1, plan.totalFrames);
+    }
+
+    throwIfAborted(signal);
+    return { blob: await encoder.finalize(), width, height };
+  } catch (error) {
+    encoder.abort();
+    throw error;
+  } finally {
+    map.remove();
+    container.remove();
+  }
+}

--- a/src/utils/videoExport/videoStats.js
+++ b/src/utils/videoExport/videoStats.js
@@ -1,0 +1,94 @@
+// Route statistics for the video HUD and end card. Distance and moving time
+// skip pairs separated by more than the gap threshold — the same split rule
+// pointsToTrackGeoJSON uses for the drawn track.
+import { haversineDistance } from '../geo';
+
+const DEFAULT_GAP_MINUTES = 60;
+const KM_PER_MILE = 1.609344;
+
+function isValidPoint(point) {
+  return (
+    point != null &&
+    Number.isFinite(point.lat) &&
+    Number.isFinite(point.lon) &&
+    Math.abs(point.lat) <= 90 &&
+    Math.abs(point.lon) <= 180
+  );
+}
+
+export function computeTrackStats(points, { gapMinutes = DEFAULT_GAP_MINUTES } = {}) {
+  const valid = (Array.isArray(points) ? points : []).filter(isValidPoint);
+
+  const timed = [];
+  const timeless = [];
+  for (const point of valid) {
+    const ts = point.time ? Date.parse(point.time) : Number.NaN;
+    if (Number.isNaN(ts)) timeless.push(point);
+    else timed.push({ ...point, ts });
+  }
+  timed.sort((a, b) => a.ts - b.ts);
+
+  const gapMs = gapMinutes * 60 * 1000;
+  let distanceM = 0;
+  let movingTimeMs = 0;
+
+  for (let i = 1; i < timed.length; i += 1) {
+    const dt = timed[i].ts - timed[i - 1].ts;
+    if (dt > gapMs) continue;
+    distanceM += haversineDistance(timed[i - 1].lat, timed[i - 1].lon, timed[i].lat, timed[i].lon);
+    movingTimeMs += dt;
+  }
+  for (let i = 1; i < timeless.length; i += 1) {
+    distanceM += haversineDistance(
+      timeless[i - 1].lat,
+      timeless[i - 1].lon,
+      timeless[i].lat,
+      timeless[i].lon,
+    );
+  }
+
+  const avgSpeedKmh =
+    movingTimeMs > 0 ? distanceM / 1000 / (movingTimeMs / (60 * 60 * 1000)) : null;
+
+  return { distanceM, movingTimeMs, avgSpeedKmh, pointCount: valid.length };
+}
+
+export function formatDistance(meters, units = 'km') {
+  if (!Number.isFinite(meters)) return '—';
+  if (units === 'mi') return `${(meters / 1000 / KM_PER_MILE).toFixed(1)} mi`;
+  if (meters < 1000) return `${Math.round(meters)} m`;
+  return `${(meters / 1000).toFixed(1)} km`;
+}
+
+export function formatDuration(ms) {
+  if (!Number.isFinite(ms) || ms <= 0) return '—';
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds} s`;
+  const totalMinutes = Math.round(totalSeconds / 60);
+  if (totalMinutes < 60) return `${totalMinutes} min`;
+  const hours = Math.floor(totalMinutes / 60);
+  if (hours >= 48) return `${Math.round(hours / 24)} days`;
+  return `${hours} h ${totalMinutes - hours * 60} min`;
+}
+
+export function formatSpeed(kmh, units = 'km') {
+  if (!Number.isFinite(kmh)) return '—';
+  if (units === 'mi') return `${(kmh / KM_PER_MILE).toFixed(1)} mph`;
+  return `${kmh.toFixed(1)} km/h`;
+}
+
+// Below walking pace the average is an artifact of month-long location
+// history rather than a route, so the speed row is dropped.
+const MIN_MEANINGFUL_SPEED_KMH = 1;
+
+export function buildStatRows(stats, units = 'km') {
+  const rows = [
+    ['Distance', formatDistance(stats.distanceM, units)],
+    ['Duration', formatDuration(stats.movingTimeMs)],
+    [
+      'Avg speed',
+      stats.avgSpeedKmh >= MIN_MEANINGFUL_SPEED_KMH ? formatSpeed(stats.avgSpeedKmh, units) : '—',
+    ],
+  ];
+  return rows.filter(([, value]) => value !== '—');
+}

--- a/src/utils/videoExport/videoStats.test.js
+++ b/src/utils/videoExport/videoStats.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildStatRows,
+  computeTrackStats,
+  formatDistance,
+  formatDuration,
+  formatSpeed,
+} from './videoStats';
+
+const timedPoints = [
+  { lat: 52.5, lon: 13.4, time: '2026-05-01T09:00:00Z' },
+  { lat: 52.5, lon: 13.41, time: '2026-05-01T09:10:00Z' },
+  // Four-hour gap: excluded from moving time, splits the track.
+  { lat: 52.6, lon: 13.6, time: '2026-05-01T13:10:00Z' },
+  { lat: 52.6, lon: 13.61, time: '2026-05-01T13:20:00Z' },
+];
+
+describe('computeTrackStats', () => {
+  it('sums distance and moving time, excluding long gaps', () => {
+    const stats = computeTrackStats(timedPoints);
+    expect(stats.distanceM).toBeGreaterThan(1300);
+    expect(stats.distanceM).toBeLessThan(1400);
+    expect(stats.movingTimeMs).toBe(20 * 60 * 1000);
+    expect(stats.pointCount).toBe(4);
+  });
+
+  it('derives average speed from distance over moving time', () => {
+    const stats = computeTrackStats(timedPoints);
+    const expectedKmh = (stats.distanceM / 1000) / (20 / 60);
+    expect(stats.avgSpeedKmh).toBeCloseTo(expectedKmh, 3);
+  });
+
+  it('reports null speed and zero moving time without timestamps', () => {
+    const stats = computeTrackStats([
+      { lat: 52.5, lon: 13.4 },
+      { lat: 52.5, lon: 13.41 },
+    ]);
+    expect(stats.distanceM).toBeGreaterThan(600);
+    expect(stats.movingTimeMs).toBe(0);
+    expect(stats.avgSpeedKmh).toBeNull();
+  });
+
+  it('handles empty input', () => {
+    const stats = computeTrackStats([]);
+    expect(stats.distanceM).toBe(0);
+    expect(stats.avgSpeedKmh).toBeNull();
+    expect(stats.pointCount).toBe(0);
+  });
+});
+
+describe('formatters', () => {
+  it('formats distance in km and miles', () => {
+    expect(formatDistance(12345, 'km')).toBe('12.3 km');
+    expect(formatDistance(12345, 'mi')).toBe('7.7 mi');
+    expect(formatDistance(850, 'km')).toBe('850 m');
+    expect(formatDistance(850, 'mi')).toBe('0.5 mi');
+  });
+
+  it('formats durations at second, minute, and hour scale', () => {
+    expect(formatDuration(45 * 1000)).toBe('45 s');
+    expect(formatDuration(38 * 60 * 1000)).toBe('38 min');
+    expect(formatDuration((84 * 60 + 3600) * 1000)).toBe('2 h 24 min');
+    expect(formatDuration(0)).toBe('—');
+  });
+
+  it('formats multi-day durations as days, not hundreds of hours', () => {
+    expect(formatDuration(48 * 3600 * 1000)).toBe('2 days');
+    expect(formatDuration(435.66 * 3600 * 1000)).toBe('18 days');
+    expect(formatDuration(47 * 3600 * 1000)).toBe('47 h 0 min');
+  });
+
+  it('formats speed per unit system', () => {
+    expect(formatSpeed(12.34, 'km')).toBe('12.3 km/h');
+    expect(formatSpeed(12.34, 'mi')).toBe('7.7 mph');
+    expect(formatSpeed(null, 'km')).toBe('—');
+  });
+});
+
+describe('buildStatRows', () => {
+  const base = { distanceM: 194300, movingTimeMs: 90 * 60 * 1000, avgSpeedKmh: 5.2 };
+
+  it('includes distance, duration, and speed for a normal track', () => {
+    const rows = buildStatRows(base, 'km');
+    expect(rows.map(([label]) => label)).toEqual(['Distance', 'Duration', 'Avg speed']);
+    expect(rows[0][1]).toBe('194.3 km');
+  });
+
+  it('drops average speed below walking pace — location history, not a workout', () => {
+    const rows = buildStatRows({ ...base, avgSpeedKmh: 0.4 }, 'km');
+    expect(rows.map(([label]) => label)).toEqual(['Distance', 'Duration']);
+  });
+
+  it('drops duration and speed when there are no timestamps', () => {
+    const rows = buildStatRows({ distanceM: 1000, movingTimeMs: 0, avgSpeedKmh: null }, 'km');
+    expect(rows.map(([label]) => label)).toEqual(['Distance']);
+  });
+});


### PR DESCRIPTION
## What

New free tool at `/tools/route-video-maker`: drop a GPX, Google Timeline, KML, KMZ, FIT, TCX or GeoJSON file and render an animated route-replay MP4 — entirely client-side (MapLibre GL + WebCodecs + mp4-muxer). No upload, no server, deploys as static files with the site.

## Highlights

- **Studio UI**: dark editor canvas — live preview in the output aspect (9:16 / 16:9 / 1:1), 17 poster themes as visual swatches, overview or follow-the-pen camera, render progress with frame counts, result plays back inside the preview frame
- **Broadcast HUD** (from the Replay Frames design): playhead date + day counter, live distance, progress timeline with start/end dates; 3s summary frame with date range, total distance, `https://dawarich.app` branding (not optional)
- **Motion polish**: distance-paced drawing with eased intro/outro, bounded Chaikin corner smoothing, recency fade (dim history, bright fresh trail via line-gradient), cinematic zoom-out into the summary
- **Codecs**: H.264 preferred, VP9/AV1 fallback via `VideoEncoder.isConfigSupported`; unsupported browsers keep the preview and get a clear message
- **Reuse**: poster-studio lib untouched (styles/themes/parsers/demo route imported, never edited); same page shell as the poster maker incl. SaveToAccount handoff
- **SEO**: targets the `gpx to video` and Google Timeline → travel video clusters; three new FAQs; first-slot internal links from Timeline Visualizer and Timeline Converter

## Verification

- 275 vitest specs green (59 new, TDD throughout)
- `npm run build` green
- Playwright E2E against the dev server: demo render, GPX upload render, follow mode, timestampless-file fallback — ffprobe-verified MP4s (h264, exact frame counts), zero console errors
- 390px mobile: no horizontal overflow

New dependency: `mp4-muxer`. Fonts (Archivo + JetBrains Mono) load from Google Fonts at render time with a 3s timeout fallback.