### PR TITLE
docs: document GPX waypoint import as places

### DIFF
--- a/docs/features/visits-and-places.md
+++ b/docs/features/visits-and-places.md
@@ -42,6 +42,8 @@ In the visit popup, you can:
 
 Places are saved locations that can be associated with visits. When you confirm a visit, the location is saved as a place.
 
+Places can also come from a file you import. Waypoints in a GPX file — for example the favourites exported by OsmAnd+ as `favourites.gpx` — are imported as places rather than as timeline points, and their category becomes a tag. See [Waypoints and favourites](/docs/getting-started/import-existing-data#waypoints-and-favourites) for details.
+
 ### Managing Places
 
 - Places can be viewed and managed in the Places section

--- a/docs/getting-started/import-existing-data.md
+++ b/docs/getting-started/import-existing-data.md
@@ -88,11 +88,30 @@ Hit "Create Import" and your data will be imported in the background.
 
 ### GPX routes
 
-GPX is a common format for storing GPS data. You can import your GPX routes to Dawarich. Important: Dawarich supports only GPX files of recorded routes, not planned ones.
+GPX is a common format for storing GPS data. You can import your GPX routes to Dawarich. Important: Dawarich imports recorded routes, not planned ones — a route you plotted in advance (`<rte>`) is ignored. Saved waypoints are imported as places; see [Waypoints and favourites](#waypoints-and-favourites) below.
 
 Select `GPX` as the source of your data and select the GPX file to upload.
 
 Hit "Create Import" and your data will be imported in the background.
+
+#### Waypoints and favourites
+
+A GPX file can hold two different kinds of data: a recorded track (`<trkpt>`) and individual waypoints (`<wpt>`). Apps such as OsmAnd+ export your saved favourites as a waypoint-only file, usually named `favourites.gpx`.
+
+Dawarich imports both:
+
+- **Trackpoints** become location points on your timeline, and count towards your distance and statistics.
+- **Waypoints** become [places](/docs/features/visits-and-places), and are shown on the map. They never become timeline points, so a favourite you saved while browsing the map at home will not invent a visit or add distance you never travelled.
+
+If a waypoint has a category, that category becomes a tag on the place, so you can show and hide groups of favourites on the map. Colours set in the source app are carried over to newly created tags; a tag you already styled yourself is never repainted. Favourites are never added to a tag that has a privacy zone radius — an imported file cannot widen a privacy zone, so your existing shared links keep showing what they showed before. You can attach such a tag yourself afterwards if you want to.
+
+Waypoints are matched on re-import by name and position, so importing an updated `favourites.gpx` adds only what is new instead of duplicating everything. This means you can point the [import watcher](/docs/self-hosting/monitoring/watcher) at a favourites file and let it stay in sync as you add favourites on your phone.
+
+:::note
+
+A GPX file that contains only waypoints imports 0 points, which is expected — look for the results under Places rather than on your timeline.
+
+:::
 
 ### Immich
 


### PR DESCRIPTION
Documents the behaviour added in Freika/dawarich#3479 (closes Freika/dawarich#1261). Merge after that ships.

## Why

The GPX section said Dawarich imports recorded routes and said nothing about waypoints. Freika/dawarich#1261 exists precisely because that behaviour was silent and undocumented — shipping the fix without documenting it would repeat the same mistake.

## Changes

**`docs/getting-started/import-existing-data.md`** — new "Waypoints and favourites" subsection covering:
- the `<trkpt>` vs `<wpt>` distinction, and that OsmAnd+ exports favourites as a waypoint-only file
- waypoints become places, never timeline points, so they do not affect distance or statistics
- category-to-tag mapping, colour carry-over, and that existing tag styling is preserved
- the privacy-zone carve-out, so nobody is surprised that a favourite did not join their "Home" zone
- re-import matching, and the link to the import watcher for keeping a favourites file in sync

Also tightened the opening line, which claimed only recorded routes are imported — now accurate about planned routes (`<rte>`) being ignored while waypoints are not.

**`docs/features/visits-and-places.md`** — notes that places can originate from an imported file, linking back to the section above.

## Verification

`npm run build` passes. The two remaining build warnings (undefined blog tags, and a `#pricing` anchor on `/cloud/`) are pre-existing on `main` and unrelated.
