### PR TITLE
fix: gate Google Ads behind Consent Mode instead of loading it unconditionally

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -6,6 +6,7 @@
 
 import {themes as prismThemes} from 'prism-react-renderer';
 import {footerLinks} from './src/data/footerLinks.js';
+import {buildConsentBootstrapScript, GOOGLE_ADS_ID} from './src/utils/consent.js';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -31,23 +32,26 @@ const config = {
       async: true
     },
     {
-      src: "https://www.googletagmanager.com/gtag/js?id=AW-17899851408",
-      async: true
-    },
-    {
       src: "https://rybbit.dwri.xyz/api/script.js",
       "data-site-id": "18ca92af4f9c",
       defer: true
     }
   ],
 
-  // Google Ads gtag bootstrap + cross-domain linker.
-  // The linker rewrites outbound links to my.dawarich.app to include a `_gl`
-  // param carrying the gclid + client_id. Without this, ad-click attribution
-  // is lost when users navigate from the marketing site to the manager,
-  // because the gclid cookie is scoped to dawarich.app only.
-  // We disable send_page_view because pageview events are not configured as
-  // conversions in Google Ads — sending them would just be noise.
+  // Google Ads gtag, gated by Consent Mode v2 (see src/utils/consent.js).
+  //
+  // The tag loads on every page because the cross-domain linker only works
+  // while it is present — it rewrites outbound links to my.dawarich.app with a
+  // `_gl` param carrying the gclid, which would otherwise be lost across the
+  // subdomain boundary. But it loads *denied*: no `_gcl_au`, no ad or
+  // analytics storage, until the visitor accepts. `url_passthrough` keeps
+  // attribution alive on the URL for everyone who never does.
+  //
+  // Order matters. The bootstrap must be emitted before the loader so the
+  // denied default is already in dataLayer when gtag.js first reads it.
+  // src/utils/trackingConsentConfig.test.js guards both that ordering and the
+  // absence of any second loader in `scripts`.
+  // send_page_view stays off because pageviews are not Google Ads conversions.
   headTags: [
     {
       tagName: "link",
@@ -80,15 +84,14 @@ const config = {
     {
       tagName: "script",
       attributes: {},
-      innerHTML: `
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', 'AW-17899851408', {
-          send_page_view: false,
-          linker: { domains: ['dawarich.app', 'my.dawarich.app'] }
-        });
-      `,
+      innerHTML: buildConsentBootstrapScript(),
+    },
+    {
+      tagName: "script",
+      attributes: {
+        src: `https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ADS_ID}`,
+        async: "true",
+      },
     },
   ],
 

--- a/src/components/CookieConsent.js
+++ b/src/components/CookieConsent.js
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import CookieConsent from 'react-cookie-consent';
 import { saveReferralKey, clearReferralKey } from '@site/src/utils/utm';
 import {
+  CONSENT_COOKIE_NAME,
   denyGoogleConsent,
   grantGoogleConsent,
   hasAcceptedConsent,
@@ -15,7 +16,12 @@ export default function CustomCookieConsent() {
   // earlier by the head bootstrap, which reads the same cookie synchronously.
   useEffect(() => {
     if (!hasAcceptedConsent()) return;
-    loadConsentedIntegrations();
+    try {
+      loadConsentedIntegrations();
+    } catch {
+      // A hardened context can refuse the append. Losing an optional tag is
+      // survivable; letting the throw reach the root boundary is not.
+    }
   }, []);
 
   const handleAccept = () => {
@@ -26,7 +32,11 @@ export default function CustomCookieConsent() {
     // The Google tag is already loaded and denied; flip it rather than
     // appending a second loader.
     grantGoogleConsent();
-    loadConsentedIntegrations();
+    try {
+      loadConsentedIntegrations();
+    } catch {
+      // As above: consent is recorded either way.
+    }
   };
 
   const handleDecline = () => {
@@ -57,8 +67,7 @@ export default function CustomCookieConsent() {
       buttonText="Accept"
       declineButtonText="Reject"
       enableDeclineButton
-      cookieName="dawarichCookieConsent"
-      domain=".dawarich.app"
+      cookieName={CONSENT_COOKIE_NAME}
       style={{
         background: "#2B373B",
         zIndex: 9999,
@@ -71,10 +80,12 @@ export default function CustomCookieConsent() {
       onAccept={handleAccept}
       onDecline={handleDecline}
     >
-      We use cookieless analytics (Simple Analytics and Rybbit), which needs no consent.
-      Nothing is stored on your device for advertising, email or affiliate tracking
-      unless you accept: Google Ads runs with storage switched off, and the Brevo and
-      Partnero tags are not loaded at all, until you click "Accept".
+      We use Simple Analytics, which is cookieless, and self-hosted Rybbit, which counts
+      repeat visits using an ID in your browser — neither sends anything to an advertiser.
+      Nothing is stored on your device for advertising, email or affiliate tracking unless
+      you accept: Google Ads loads with storage switched off — it still tells Google which
+      page you opened, but sets nothing on your device — and the Brevo and Partnero tags
+      are not loaded at all, until you click "Accept".
       <a
         href="/privacy-policy#cookies"
         style={{

--- a/src/components/CookieConsent.js
+++ b/src/components/CookieConsent.js
@@ -1,63 +1,37 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import CookieConsent from 'react-cookie-consent';
 import { saveReferralKey, clearReferralKey } from '@site/src/utils/utm';
+import {
+  denyGoogleConsent,
+  grantGoogleConsent,
+  hasAcceptedConsent,
+  loadConsentedIntegrations,
+} from '@site/src/utils/consent';
 
 export default function CustomCookieConsent() {
+  // react-cookie-consent fires onAccept only on the click itself, never on
+  // mount, so without this a returning visitor who accepted months ago got
+  // none of the tags they consented to. The Google tag is already handled
+  // earlier by the head bootstrap, which reads the same cookie synchronously.
+  useEffect(() => {
+    if (!hasAcceptedConsent()) return;
+    loadConsentedIntegrations();
+  }, []);
+
   const handleAccept = () => {
     // Page load refused to store the affiliate key without consent, so capture it
     // now — the referral link's query param is still on the URL at this point.
     saveReferralKey();
 
-    const gtagScript = document.createElement('script');
-    gtagScript.src = 'https://www.googletagmanager.com/gtag/js?id=AW-17899851408';
-    gtagScript.async = true;
-    document.head.appendChild(gtagScript);
+    // The Google tag is already loaded and denied; flip it rather than
+    // appending a second loader.
+    grantGoogleConsent();
+    loadConsentedIntegrations();
+  };
 
-    gtagScript.onload = () => {
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){window.dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'AW-17899851408');
-    };
-
-    const brevoScript = document.createElement('script');
-    brevoScript.src = 'https://cdn.brevo.com/js/sdk-loader.js';
-    brevoScript.async = true;
-    document.head.appendChild(brevoScript);
-
-    brevoScript.onload = () => {
-      window.Brevo = window.Brevo || [];
-      window.Brevo.push([
-        "init",
-        {
-          client_key: "pe4hklelof20ofjrbum6bcx8"
-        }
-      ]);
-    };
-
-    // Affiliate attribution. The cookie this sets is not strictly necessary
-    // under § 25 TTDSG, so it waits for consent like the two above. Attribution
-    // itself does not depend on it — the `via` key travels to the app on the
-    // CTA URL (see src/utils/utm.js), so declining costs Partnero only its own
-    // click statistics.
-    (function (p, t, n, e, r, o) {
-      p['__partnerObject'] = r;
-      function f() {
-        var c = { a: arguments, q: [] };
-        var r = this.push(c);
-        return typeof r != "number" ? r : f.bind(c.q);
-      }
-      f.q = f.q || [];
-      p[r] = p[r] || f.bind(f.q);
-      p[r].q = p[r].q || f.q;
-      o = t.createElement(n);
-      var _ = t.getElementsByTagName(n)[0];
-      o.async = 1;
-      o.src = e + '?v' + (~~(new Date().getTime() / 1e6));
-      _.parentNode.insertBefore(o, _);
-    })(window, document, 'script', 'https://app.partnero.com/js/universal.js', 'po');
-    window.po('settings', 'assets_host', 'https://assets.partnero.com');
-    window.po('program', '1NNVU1NU', 'load');
+  const handleDecline = () => {
+    denyGoogleConsent();
+    clearReferralKey();
   };
 
   const buttonStyle = {
@@ -95,11 +69,12 @@ export default function CustomCookieConsent() {
       declineButtonStyle={declineButtonStyle}
       expires={150}
       onAccept={handleAccept}
-      onDecline={clearReferralKey}
+      onDecline={handleDecline}
     >
-      We use a cookieless analytics service (Simple Analytics) that requires no consent.
-      You can optionally accept cookies for Google Ads conversion tracking, Brevo email
-      analytics and affiliate referral credit — these only load if you click "Accept".
+      We use cookieless analytics (Simple Analytics and Rybbit), which needs no consent.
+      Nothing is stored on your device for advertising, email or affiliate tracking
+      unless you accept: Google Ads runs with storage switched off, and the Brevo and
+      Partnero tags are not loaded at all, until you click "Accept".
       <a
         href="/privacy-policy#cookies"
         style={{

--- a/src/components/CookieConsent.test.js
+++ b/src/components/CookieConsent.test.js
@@ -1,16 +1,16 @@
 import React from 'react';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import CustomCookieConsent from './CookieConsent';
-import { CONSENT_COOKIE_NAME, resetConsentedIntegrationsForTest } from '@site/src/utils/consent';
+import { CONSENT_COOKIE_NAME } from '@site/src/utils/consent';
 
 function setConsentCookie(value) {
   document.cookie = `${CONSENT_COOKIE_NAME}=${value}; path=/`;
 }
 
-// The banner writes its cookie with `domain=.dawarich.app`, so expiring it
-// needs the same domain attribute or the value survives into the next test and
-// the banner mounts hidden.
+// react-cookie-consent v9 drops an unsupported `domain` prop, so the banner's
+// cookie is host-only on `path=/`. The domain-scoped expiry is kept only to
+// clear a cookie left over from a version where the attribute did apply.
 function clearConsentCookie() {
   const expiry = 'expires=Thu, 01 Jan 1970 00:00:00 GMT';
   document.cookie = `${CONSENT_COOKIE_NAME}=; path=/; ${expiry}`;
@@ -31,7 +31,7 @@ beforeEach(() => {
   clearConsentCookie();
   document.head.innerHTML = '';
   window.dataLayer = [];
-  resetConsentedIntegrationsForTest();
+  delete window.po;
 });
 
 afterEach(cleanup);
@@ -58,6 +58,17 @@ describe('CustomCookieConsent', () => {
 
     expect(srcs.some((s) => s.includes('brevo.com'))).toBe(true);
     expect(srcs.some((s) => s.includes('partnero.com'))).toBe(true);
+  });
+
+  it('survives a blocked script append instead of tearing down the page', () => {
+    setConsentCookie('true');
+    const spy = vi.spyOn(document.head, 'appendChild').mockImplementation(() => {
+      throw new Error('blocked by content security policy');
+    });
+
+    expect(() => render(<CustomCookieConsent />)).not.toThrow();
+
+    spy.mockRestore();
   });
 
   it('grants consent and loads the tags when Accept is clicked', () => {

--- a/src/components/CookieConsent.test.js
+++ b/src/components/CookieConsent.test.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import CustomCookieConsent from './CookieConsent';
+import { CONSENT_COOKIE_NAME, resetConsentedIntegrationsForTest } from '@site/src/utils/consent';
+
+function setConsentCookie(value) {
+  document.cookie = `${CONSENT_COOKIE_NAME}=${value}; path=/`;
+}
+
+// The banner writes its cookie with `domain=.dawarich.app`, so expiring it
+// needs the same domain attribute or the value survives into the next test and
+// the banner mounts hidden.
+function clearConsentCookie() {
+  const expiry = 'expires=Thu, 01 Jan 1970 00:00:00 GMT';
+  document.cookie = `${CONSENT_COOKIE_NAME}=; path=/; ${expiry}`;
+  document.cookie = `${CONSENT_COOKIE_NAME}=; path=/; domain=.dawarich.app; ${expiry}`;
+}
+
+function loadedThirdParties() {
+  return Array.from(document.querySelectorAll('script')).map((s) => s.src);
+}
+
+function consentUpdates() {
+  return (window.dataLayer || [])
+    .map((args) => Array.from(args))
+    .filter((c) => c[0] === 'consent' && c[1] === 'update');
+}
+
+beforeEach(() => {
+  clearConsentCookie();
+  document.head.innerHTML = '';
+  window.dataLayer = [];
+  resetConsentedIntegrationsForTest();
+});
+
+afterEach(cleanup);
+
+describe('CustomCookieConsent', () => {
+  it('loads no consented tag before the visitor answers the banner', () => {
+    render(<CustomCookieConsent />);
+
+    expect(loadedThirdParties()).toHaveLength(0);
+    expect(consentUpdates()).toHaveLength(0);
+  });
+
+  it('loads no consented tag for a visitor who declined', () => {
+    setConsentCookie('false');
+    render(<CustomCookieConsent />);
+
+    expect(loadedThirdParties()).toHaveLength(0);
+  });
+
+  it('honours stored consent on mount for a returning visitor', () => {
+    setConsentCookie('true');
+    render(<CustomCookieConsent />);
+    const srcs = loadedThirdParties();
+
+    expect(srcs.some((s) => s.includes('brevo.com'))).toBe(true);
+    expect(srcs.some((s) => s.includes('partnero.com'))).toBe(true);
+  });
+
+  it('grants consent and loads the tags when Accept is clicked', () => {
+    render(<CustomCookieConsent />);
+    fireEvent.click(screen.getByText('Accept'));
+
+    expect(consentUpdates()[0][2].ad_storage).toBe('granted');
+    expect(loadedThirdParties().some((s) => s.includes('brevo.com'))).toBe(true);
+  });
+
+  it('does not append a second Google tag loader on Accept', () => {
+    render(<CustomCookieConsent />);
+    fireEvent.click(screen.getByText('Accept'));
+
+    const loaders = loadedThirdParties().filter((s) => s.includes('googletagmanager.com'));
+    expect(loaders).toHaveLength(0);
+  });
+
+  it('re-denies consent and loads nothing when Reject is clicked', () => {
+    render(<CustomCookieConsent />);
+    fireEvent.click(screen.getByText('Reject'));
+
+    expect(consentUpdates()[0][2].ad_storage).toBe('denied');
+    expect(loadedThirdParties()).toHaveLength(0);
+  });
+});

--- a/src/components/CookiePreferences.js
+++ b/src/components/CookiePreferences.js
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react';
+import {
+  CONSENT_ACCEPTED,
+  CONSENT_DECLINED,
+  readConsentChoice,
+  revokeConsent,
+} from '@site/src/utils/consent';
+import { clearReferralKey } from '@site/src/utils/utm';
+
+const buttonStyle = {
+  color: '#fff',
+  backgroundColor: '#1670B7',
+  fontSize: '15px',
+  fontWeight: 'bold',
+  borderRadius: '5px',
+  border: 'none',
+  padding: '8px 16px',
+  cursor: 'pointer',
+};
+
+export default function CookiePreferences({ reload = () => window.location.reload() }) {
+  // The prerendered HTML cannot know what this visitor chose, so the cookie is
+  // read after mount and the first client render matches the server's.
+  const [choice, setChoice] = useState(null);
+
+  useEffect(() => {
+    setChoice(readConsentChoice());
+  }, []);
+
+  // Both buttons do the same thing: drop the stored answer, re-deny Google, and
+  // reload. Brevo and Partnero are already executing and cannot be unloaded, and
+  // the banner reads its cookie only when it first mounts — which Docusaurus
+  // never does again during client-side navigation.
+  // clearReferralKey lives in utm.js, which already reads consent.js — calling it
+  // from here rather than from revokeConsent keeps that dependency one-way.
+  const startOver = () => {
+    revokeConsent();
+    clearReferralKey();
+    reload();
+  };
+
+  // Before the cookie has been read — the prerendered page, and any visit
+  // without JavaScript — only the manual route can be offered honestly.
+  if (choice === null) {
+    return (
+      <p>
+        Delete the <code>dawarichCookieConsent</code> cookie and reload the page. With
+        JavaScript enabled, a one-click button appears here instead.
+      </p>
+    );
+  }
+
+  if (choice === CONSENT_ACCEPTED) {
+    return (
+      <button type="button" style={buttonStyle} onClick={startOver}>
+        Withdraw consent
+      </button>
+    );
+  }
+
+  if (choice === CONSENT_DECLINED) {
+    return (
+      <p>
+        You declined, so nothing is stored on your device for advertising, email or
+        affiliate tracking. To reconsider:{' '}
+        <button type="button" style={buttonStyle} onClick={startOver}>
+          Choose again
+        </button>
+      </p>
+    );
+  }
+
+  return (
+    <p>
+      The cookie banner is still waiting for your answer, so nothing is stored on your
+      device for advertising, email or affiliate tracking.
+    </p>
+  );
+}

--- a/src/components/CookiePreferences.test.js
+++ b/src/components/CookiePreferences.test.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { renderToString } from 'react-dom/server';
+import CookiePreferences from './CookiePreferences';
+import { CONSENT_COOKIE_NAME, hasAcceptedConsent } from '@site/src/utils/consent';
+
+function clearConsentCookie() {
+  document.cookie = `${CONSENT_COOKIE_NAME}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+}
+
+beforeEach(() => {
+  clearConsentCookie();
+  window.dataLayer = [];
+});
+
+afterEach(cleanup);
+
+describe('CookiePreferences', () => {
+  // Docusaurus prerenders this page, and the prerender cannot read a cookie. A
+  // visitor without JavaScript never gets past that first render, so it has to
+  // carry the manual instruction rather than an empty gap under the heading.
+  it('prerenders the manual instruction rather than nothing', () => {
+    const html = renderToString(<CookiePreferences />);
+
+    expect(html).toContain('dawarichCookieConsent');
+    expect(html).not.toContain('Withdraw consent');
+  });
+
+  it('offers a withdrawal control to a visitor who accepted', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=true; path=/`;
+    render(<CookiePreferences reload={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: /withdraw consent/i })).toBeTruthy();
+  });
+
+  // Offering to withdraw something that was never given, and then confirming it
+  // was switched "off again", tells the visitor their data was being collected.
+  it('offers nothing to withdraw while the banner is still unanswered', () => {
+    render(<CookiePreferences reload={vi.fn()} />);
+
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.getByText(/still waiting for your answer/i)).toBeTruthy();
+  });
+
+  // The banner shows itself only while its cookie is absent, so a decline is
+  // otherwise a one-way door — withdrawing would be one click and reconsidering
+  // would mean deleting a cookie by hand.
+  it('lets a visitor who declined reopen the choice', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=false; path=/`;
+    render(<CookiePreferences reload={vi.fn()} />);
+
+    expect(screen.queryByRole('button', { name: /withdraw consent/i })).toBeNull();
+    expect(screen.getByRole('button', { name: /choose again/i })).toBeTruthy();
+  });
+
+  it('clears the decline and reloads so the banner returns', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=false; path=/`;
+    const reload = vi.fn();
+    render(<CookiePreferences reload={reload} />);
+    fireEvent.click(screen.getByRole('button', { name: /choose again/i }));
+
+    expect(document.cookie.includes(`${CONSENT_COOKIE_NAME}=false`)).toBe(false);
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the stored consent when clicked', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=true; path=/`;
+    render(<CookiePreferences reload={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /withdraw consent/i }));
+
+    expect(hasAcceptedConsent()).toBe(false);
+  });
+
+  it('re-denies Google storage in the live tag rather than only on next load', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=true; path=/`;
+    render(<CookiePreferences reload={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /withdraw consent/i }));
+
+    const update = window.dataLayer.map((a) => Array.from(a)).find((c) => c[1] === 'update');
+    expect(update[2].ad_storage).toBe('denied');
+  });
+
+  // The affiliate key was only stored because consent allowed it, so it has to go
+  // with the consent rather than waiting for the next read to notice.
+  it('drops the stored affiliate key along with the consent', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=true; path=/`;
+    localStorage.setItem(
+      'partnero_referral',
+      JSON.stringify({ key: 'abc', param: 'via', timestamp: Date.now() }),
+    );
+    render(<CookiePreferences reload={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /withdraw consent/i }));
+
+    expect(localStorage.getItem('partnero_referral')).toBeNull();
+  });
+
+  // Brevo and Partnero are already executing in this page and cannot be unloaded,
+  // and the banner reads its cookie only when it first mounts — which Docusaurus
+  // never does again during client-side navigation. Only a reload finishes the job.
+  it('reloads the page so the running tags stop and the banner asks again', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=true; path=/`;
+    const reload = vi.fn();
+    render(<CookiePreferences reload={reload} />);
+    fireEvent.click(screen.getByRole('button', { name: /withdraw consent/i }));
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/data/footerLinks.js
+++ b/src/data/footerLinks.js
@@ -1,4 +1,4 @@
-export const FOOTER_LINK_CAP = 60;
+export const FOOTER_LINK_CAP = 61;
 
 const BRAND_HTML =
   '<p style="display:inline-flex;align-items:center;gap:0.375rem;margin:0 0 0.5rem;"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/></svg><span>Made and hosted in Europe</span></p><p>&copy;ZeitFlow UG (haftungsbeschränkt)</p><p>Berlin, Germany</p><p class="dawarich-footer-cta"><a href="https://my.dawarich.app/users/sign_up?utm_source=site&utm_medium=footer&utm_campaign=footer_cta">Start tracking →</a></p>';
@@ -89,6 +89,7 @@ export const footerLinks = [
       { label: 'Credits', to: '/credits' },
       { label: 'Impressum', to: '/impressum' },
       { label: 'Privacy Policy', to: '/privacy-policy' },
+      { label: 'Cookie Settings', to: '/privacy-policy#cookies' },
       { label: 'Terms and Conditions', to: '/terms-and-conditions' },
       { label: 'Refund Policy', to: '/refund-policy' },
     ],

--- a/src/data/footerLinks.test.js
+++ b/src/data/footerLinks.test.js
@@ -90,6 +90,14 @@ describe('footerLinks', () => {
   });
 
   it('pins FOOTER_LINK_CAP to its specified value', () => {
-    expect(FOOTER_LINK_CAP).toBe(60);
+    expect(FOOTER_LINK_CAP).toBe(61);
+  });
+
+  // Withdrawing consent has to be as easy as giving it, and the banner that
+  // gives it in one click from any page is gone for good once answered. The
+  // footer is the only element that persists everywhere afterwards.
+  it('reaches the cookie controls from every page', () => {
+    const company = footerLinks.find((c) => c.title === 'Company').items.map((i) => i.to);
+    expect(company).toContain('/privacy-policy#cookies');
   });
 });

--- a/src/pages/privacy-policy.md
+++ b/src/pages/privacy-policy.md
@@ -2,6 +2,8 @@
 title: Privacy Policy
 ---
 
+import CookiePreferences from '@site/src/components/CookiePreferences';
+
 # Dawarich Privacy Policy
 
 :::info TL;DR
@@ -52,6 +54,8 @@ All listed processors are bound by DPAs under Art. 28 GDPR. We do not sell data 
 | Gelato ASA | Poster printing and shipping (receives shipping details and the poster file) | Norway (EEA); production within the EU |
 | Partnero, Inc. | Affiliate-referral attribution — receives your email and name only if you arrived via an affiliate link | United States |
 
+Rybbit, the analytics tool named in section 6, runs on our own Hetzner infrastructure (`rybbit.dwri.xyz`) rather than a vendor's hosted service, so it adds no processor to this table — no third party receives that data.
+
 **International transfers:** UK (Paddle) is covered by the EU adequacy decision. Norway (Gelato) is in the EEA, where the GDPR applies directly. US transfers rely on the EU-US Data Privacy Framework where the provider is certified, and on Standard Contractual Clauses (Art. 46 GDPR) otherwise.
 
 ## 4. Retention
@@ -78,14 +82,25 @@ On `dawarich.app` we use:
 | Category | Purpose | Consent? | Provider |
 |---|---|---|---|
 | Strictly necessary | Remember your banner choice | No (§ 25(2) TTDSG) | First-party |
-| Cookieless analytics | Aggregate traffic | No | Simple Analytics, Rybbit |
-| Advertising | Google Ads conversion tracking | **Yes** | Google Ads |
+| Cookieless analytics | Aggregate traffic | No | Simple Analytics |
+| Site analytics | Aggregate traffic; stores a visitor ID in your browser's local storage | Not currently asked | Rybbit (self-hosted) |
+| Advertising | Google Ads conversion tracking — tag present on every page, storage denied until you accept | **Yes**, for storage | Google Ads |
 | Email analytics | Brevo tracking pixel | **Yes** | Brevo |
 | Affiliate attribution | Credit a referring partner for a sign-up | **Yes** | Partnero |
 
+Rybbit stores a randomly generated visitor ID in your browser's local storage so that repeat visits are counted as one visitor rather than several. It is written on the first page you open, before the banner appears, and we do not currently ask for consent before writing it. It contains no personal data, is never sent to a third party, and you can remove it by clearing site data for `dawarich.app`.
+
 The Google Ads tag is present on every page, but it runs under Google Consent Mode with `ad_storage`, `ad_user_data`, `ad_personalization` and `analytics_storage` all set to **denied** until you accept. In that state it writes no cookies and no identifiers to your device; if you never accept, or you decline, it stays denied. The Brevo and Partnero tags are not loaded at all before consent.
 
-To withdraw consent after accepting, delete the `dawarichCookieConsent` cookie and reload. On `my.dawarich.app` we additionally use first-party session cookies strictly necessary for login.
+Because the tag itself loads, it does send Google a cookieless request on each page view containing the page address, your IP address and browser user agent, with ad-click identifiers redacted. It sets nothing on your device and carries no identifier that would let Google recognise you on someone else's site — but it happens whether or not you accept.
+
+If you reached us from one of our ads, the tag also copies the ad-click identifier Google placed in your landing URL (`gclid`, alongside a `_gl` parameter) onto links you follow to `my.dawarich.app`, so that the click and the sign-up can be matched. This travels in the address bar rather than in a cookie, is limited to our own two domains, and also happens whether or not you accept. It is the reason we keep the tag loaded at all: without it, that link between an ad click and a sign-up is lost.
+
+To change your mind either way, use the control below — the **Cookie Settings** link in the footer of every page brings you back here. It clears your stored answer, switches Google Ads storage back off straight away, and reloads the page so the Brevo and Partnero tags stop running and the banner asks you again.
+
+<CookiePreferences />
+
+On `my.dawarich.app` we additionally use first-party session cookies strictly necessary for login.
 
 ## 7. Security
 
@@ -109,7 +124,7 @@ Effective **2026-09-02**. Contact for all privacy matters: **hi@dawarich.app**.
 
 | When          | What          |
 | ------------- | ------------- |
-| 2026-09-02    | Google Ads now loads denied-by-default under Google Consent Mode; documented that it stores nothing before consent. No new purposes or processors |
+| 2026-09-02    | Google Ads now loads denied-by-default under Google Consent Mode; disclosed the cookieless request it still sends before consent and the ad-click identifier passed to `my.dawarich.app` in the URL, and added a one-click control to withdraw or reconsider. Corrected the description of Rybbit, which stores a visitor ID rather than being cookieless, and recorded that it is self-hosted and adds no processor. No new purposes or processors |
 | 2026-08-12    | Added Partnero as a processor for affiliate-referral attribution, and the affiliate cookie to the cookie table |
 | 2026-07-28    | Disclosed tool uploads held for signup ("Save to my Dawarich account") and their 24-hour deletion window |
 | 2026-07-18    | Added poster print orders: order data, Stripe and Gelato processors, print-file retention (48h unpaid / 90 days paid) |

--- a/src/pages/privacy-policy.md
+++ b/src/pages/privacy-policy.md
@@ -43,7 +43,7 @@ All listed processors are bound by DPAs under Art. 28 GDPR. We do not sell data 
 | Paddle.com Market Ltd. | Billing, checkout, invoicing | United Kingdom |
 | Functional Software, Inc. (Sentry) | Error and crash tracking | United States |
 | Simple Analytics B.V. | Cookieless site analytics (no consent needed) | Netherlands (EU) |
-| Google LLC (Google Ads) | Marketing-site conversion tracking — consent-based | United States |
+| Google LLC (Google Ads) | Marketing-site conversion tracking — denied by default, consent-based | United States |
 | Sendinblue SAS (Brevo) — email | Transactional emails | France (EU) |
 | Sendinblue SAS (Brevo) — web tracker | Marketing-site email-campaign pixel — consent-based | France (EU) |
 | Apple Inc. | iOS App Store distribution | United States |
@@ -78,10 +78,12 @@ On `dawarich.app` we use:
 | Category | Purpose | Consent? | Provider |
 |---|---|---|---|
 | Strictly necessary | Remember your banner choice | No (§ 25(2) TTDSG) | First-party |
-| Cookieless analytics | Aggregate traffic | No | Simple Analytics |
+| Cookieless analytics | Aggregate traffic | No | Simple Analytics, Rybbit |
 | Advertising | Google Ads conversion tracking | **Yes** | Google Ads |
 | Email analytics | Brevo tracking pixel | **Yes** | Brevo |
 | Affiliate attribution | Credit a referring partner for a sign-up | **Yes** | Partnero |
+
+The Google Ads tag is present on every page, but it runs under Google Consent Mode with `ad_storage`, `ad_user_data`, `ad_personalization` and `analytics_storage` all set to **denied** until you accept. In that state it writes no cookies and no identifiers to your device; if you never accept, or you decline, it stays denied. The Brevo and Partnero tags are not loaded at all before consent.
 
 To withdraw consent after accepting, delete the `dawarichCookieConsent` cookie and reload. On `my.dawarich.app` we additionally use first-party session cookies strictly necessary for login.
 
@@ -103,10 +105,11 @@ We will notify you of **material changes** (new purposes, new processors, change
 
 ## Last updated
 
-Effective **2026-08-12**. Contact for all privacy matters: **hi@dawarich.app**.
+Effective **2026-09-02**. Contact for all privacy matters: **hi@dawarich.app**.
 
 | When          | What          |
 | ------------- | ------------- |
+| 2026-09-02    | Google Ads now loads denied-by-default under Google Consent Mode; documented that it stores nothing before consent. No new purposes or processors |
 | 2026-08-12    | Added Partnero as a processor for affiliate-referral attribution, and the affiliate cookie to the cookie table |
 | 2026-07-28    | Disclosed tool uploads held for signup ("Save to my Dawarich account") and their 24-hour deletion window |
 | 2026-07-18    | Added poster print orders: order data, Stripe and Gelato processors, print-file retention (48h unpaid / 90 days paid) |

--- a/src/pages/techlore/index.js
+++ b/src/pages/techlore/index.js
@@ -191,8 +191,9 @@ const privacyPillars = [
 			<>
 				No Google Analytics. No Meta SDK. No Mixpanel, no Segment, no
 				retargeting pixels in the product. The marketing site uses cookieless
-				Simple Analytics by default; consent-based ad-conversion pixels only
-				fire if you accept them. We make money from subscriptions, full stop.
+				Simple Analytics and self-hosted Rybbit; the Google Ads conversion tag
+				runs there with storage switched off and writes nothing to your device
+				unless you accept. We make money from subscriptions, full stop.
 			</>
 		),
 	},
@@ -244,7 +245,7 @@ const techloreFaq = [
 	{
 		question: "Do you sell data or run ads?",
 		answer:
-			"No. We're a small EU company funded by subscriptions — selling location data is illegal under GDPR, and we'd rather have a real business than be the next data broker. The product has no third-party trackers, no analytics SDKs, no Meta or Google pixels. The marketing site uses cookieless Simple Analytics by default; the only ad pixel is a Google Ads conversion tag that fires only if you accept the cookie banner.",
+			"No. We're a small EU company funded by subscriptions — selling location data is illegal under GDPR, and we'd rather have a real business than be the next data broker. The product has no third-party trackers, no analytics SDKs, no Meta or Google pixels. The marketing site uses cookieless Simple Analytics and self-hosted Rybbit; the only ad pixel is a Google Ads conversion tag, and it runs with storage switched off — it writes nothing to your device unless you accept the cookie banner.",
 	},
 	{
 		question: "Where exactly is my data stored?",

--- a/src/utils/consent.js
+++ b/src/utils/consent.js
@@ -1,8 +1,11 @@
 /**
  * Consent gating for the tags that write to a visitor's device.
  *
- * Simple Analytics and Rybbit are cookieless and stay outside this module —
- * they need no consent under § 25(2) TTDSG. Everything here does.
+ * Simple Analytics stays outside this module: it is genuinely cookieless and
+ * needs no consent under § 25(2) TTDSG. Rybbit also stays outside it, but for a
+ * different reason — it writes a `rybbit-visitor-id` to localStorage before the
+ * banner, and the decision was to disclose that in § 6 of the privacy policy
+ * rather than gate it. Do not read its absence here as "it stores nothing".
  *
  * The Google tag is a special case. It has to be present on the page before
  * the visitor clicks anything, because the cross-domain linker can only
@@ -14,6 +17,25 @@
  */
 
 export const CONSENT_COOKIE_NAME = 'dawarichCookieConsent';
+// The banner's own cookie is host-only, because react-cookie-consent v9 ignores
+// a `domain` prop. The tag cookies below are not — gtag scopes `_gcl_au` to the
+// registrable domain — so expiry is attempted on both scopes for every name.
+export const SITE_COOKIE_DOMAIN = '.dawarich.app';
+
+// Cookies that only exist because consent was given, and so must not outlive it.
+const CONSENTED_COOKIES = [
+  '_gcl_au',
+  '_gcl_aw',
+  '_gcl_dc',
+  'sib_cuid',
+  'partnero_session_uuid',
+];
+
+// The same, for the storage the tags reach for when a cookie will not do.
+// § 25 TTDSG governs writing to the device, not the mechanism used to write.
+// `partnero_referral` is absent on purpose: utm.js owns it, and clearing it
+// there keeps utm.js -> consent.js a one-way dependency.
+const CONSENTED_STORAGE_KEYS = ['_gcl_ls', '__wpfvdk', '_wpinitialpermissionstate'];
 export const GOOGLE_ADS_ID = 'AW-17899851408';
 export const LINKER_DOMAINS = ['dawarich.app', 'my.dawarich.app'];
 
@@ -62,15 +84,42 @@ gtag('config', '${GOOGLE_ADS_ID}', {
 `.trim();
 }
 
+/**
+ * gtag.js dispatches a dataLayer entry to its consent command table only when
+ * the entry is an `arguments` object — an array is read as a legacy
+ * "call this method path" instruction instead, throws, and is swallowed by an
+ * empty catch. So the push has to go through a real gtag shim, never an array
+ * literal, or the command is silently dropped and consent never changes.
+ */
 function pushConsent(state) {
   if (typeof window === 'undefined') return;
   window.dataLayer = window.dataLayer || [];
-  window.dataLayer.push(['consent', 'update', state]);
+  function gtag() {
+    window.dataLayer.push(arguments);
+  }
+  gtag('consent', 'update', state);
+}
+
+export const CONSENT_ACCEPTED = 'accepted';
+export const CONSENT_DECLINED = 'declined';
+export const CONSENT_UNANSWERED = 'unanswered';
+
+/**
+ * A declined banner and an unanswered one look the same to the tags — both mean
+ * denied — but only the first needs a way back, because the banner shows itself
+ * again while the cookie is absent and never once it has been set.
+ */
+export function readConsentChoice() {
+  if (typeof document === 'undefined') return CONSENT_UNANSWERED;
+
+  const entries = document.cookie.split('; ');
+  if (entries.indexOf(`${CONSENT_COOKIE_NAME}=true`) !== -1) return CONSENT_ACCEPTED;
+  if (entries.indexOf(`${CONSENT_COOKIE_NAME}=false`) !== -1) return CONSENT_DECLINED;
+  return CONSENT_UNANSWERED;
 }
 
 export function hasAcceptedConsent() {
-  if (typeof document === 'undefined') return false;
-  return document.cookie.split('; ').indexOf(`${CONSENT_COOKIE_NAME}=true`) !== -1;
+  return readConsentChoice() === CONSENT_ACCEPTED;
 }
 
 export function grantGoogleConsent() {
@@ -81,10 +130,36 @@ export function denyGoogleConsent() {
   pushConsent(DENIED_CONSENT);
 }
 
-let integrationsLoaded = false;
+/**
+ * Withdrawal has to be as easy as consent was to give, so this drops the stored
+ * answer and re-denies straight away rather than waiting for the next load.
+ * The banner reappears on the following render because its cookie is gone.
+ */
+function expireCookie(name) {
+  const expiry = 'expires=Thu, 01 Jan 1970 00:00:00 GMT';
+  document.cookie = `${name}=; path=/; ${expiry}`;
+  document.cookie = `${name}=; path=/; domain=${SITE_COOKIE_DOMAIN}; ${expiry}`;
+}
 
-export function resetConsentedIntegrationsForTest() {
-  integrationsLoaded = false;
+export function revokeConsent() {
+  if (typeof document === 'undefined') return;
+
+  expireCookie(CONSENT_COOKIE_NAME);
+  CONSENTED_COOKIES.forEach(expireCookie);
+
+  try {
+    CONSENTED_STORAGE_KEYS.forEach((key) => localStorage.removeItem(key));
+  } catch {
+    // Storage can be unavailable or full; the cookies are already gone.
+  }
+
+  denyGoogleConsent();
+}
+
+const TAG_MARKER = 'data-consent-tag';
+
+function alreadyLoaded(name) {
+  return document.querySelector(`script[${TAG_MARKER}="${name}"]`) !== null;
 }
 
 /**
@@ -97,17 +172,21 @@ export function resetConsentedIntegrationsForTest() {
  * visitor's stored consent was never honoured.
  */
 export function loadConsentedIntegrations() {
-  if (typeof document === 'undefined' || integrationsLoaded) return;
-  integrationsLoaded = true;
+  if (typeof document === 'undefined') return;
 
-  const brevoScript = document.createElement('script');
-  brevoScript.src = 'https://cdn.brevo.com/js/sdk-loader.js';
-  brevoScript.async = true;
-  brevoScript.onload = () => {
-    window.Brevo = window.Brevo || [];
-    window.Brevo.push(['init', { client_key: BREVO_CLIENT_KEY }]);
-  };
-  document.head.appendChild(brevoScript);
+  if (!alreadyLoaded('brevo')) {
+    const brevoScript = document.createElement('script');
+    brevoScript.src = 'https://cdn.brevo.com/js/sdk-loader.js';
+    brevoScript.async = true;
+    brevoScript.setAttribute(TAG_MARKER, 'brevo');
+    brevoScript.onload = () => {
+      window.Brevo = window.Brevo || [];
+      window.Brevo.push(['init', { client_key: BREVO_CLIENT_KEY }]);
+    };
+    document.head.appendChild(brevoScript);
+  }
+
+  if (alreadyLoaded('partnero')) return;
 
   // Partnero's queue stub has to exist before its script is appended, so calls
   // made while it downloads are replayed rather than thrown away.
@@ -124,6 +203,7 @@ export function loadConsentedIntegrations() {
   const partneroScript = document.createElement('script');
   partneroScript.src = `https://app.partnero.com/js/universal.js?v${~~(Date.now() / 1e6)}`;
   partneroScript.async = true;
+  partneroScript.setAttribute(TAG_MARKER, 'partnero');
   document.head.appendChild(partneroScript);
 
   window.po('settings', 'assets_host', 'https://assets.partnero.com');

--- a/src/utils/consent.js
+++ b/src/utils/consent.js
@@ -1,0 +1,131 @@
+/**
+ * Consent gating for the tags that write to a visitor's device.
+ *
+ * Simple Analytics and Rybbit are cookieless and stay outside this module —
+ * they need no consent under § 25(2) TTDSG. Everything here does.
+ *
+ * The Google tag is a special case. It has to be present on the page before
+ * the visitor clicks anything, because the cross-domain linker can only
+ * rewrite outbound links to my.dawarich.app while it is loaded — that is why
+ * an earlier attempt to gate it by not loading it (e9f3291) was reverted for
+ * attribution (cef12e7). Consent Mode resolves the conflict: the tag loads in
+ * a denied state where it writes no cookies, and `url_passthrough` carries the
+ * gclid on the URL instead, so attribution survives a refusal.
+ */
+
+export const CONSENT_COOKIE_NAME = 'dawarichCookieConsent';
+export const GOOGLE_ADS_ID = 'AW-17899851408';
+export const LINKER_DOMAINS = ['dawarich.app', 'my.dawarich.app'];
+
+export const DENIED_CONSENT = {
+  ad_storage: 'denied',
+  ad_user_data: 'denied',
+  ad_personalization: 'denied',
+  analytics_storage: 'denied',
+};
+
+export const GRANTED_CONSENT = {
+  ad_storage: 'granted',
+  ad_user_data: 'granted',
+  ad_personalization: 'granted',
+  analytics_storage: 'granted',
+};
+
+const BREVO_CLIENT_KEY = 'pe4hklelof20ofjrbum6bcx8';
+const PARTNERO_PROGRAM_ID = '1NNVU1NU';
+
+/**
+ * The inline script that runs in <head> ahead of the Google tag loader.
+ *
+ * It must stay self-contained: it is serialised into the document by
+ * docusaurus.config.js and executes before any bundle has loaded, so it cannot
+ * import anything. Consent has to be resolved here rather than in React —
+ * hydration happens long after the tag would otherwise have written a cookie.
+ */
+export function buildConsentBootstrapScript() {
+  return `
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('consent', 'default', ${JSON.stringify(DENIED_CONSENT)});
+gtag('set', 'ads_data_redaction', true);
+gtag('set', 'url_passthrough', true);
+try {
+  if (document.cookie.split('; ').indexOf('${CONSENT_COOKIE_NAME}=true') !== -1) {
+    gtag('consent', 'update', ${JSON.stringify(GRANTED_CONSENT)});
+  }
+} catch (e) {}
+gtag('js', new Date());
+gtag('config', '${GOOGLE_ADS_ID}', {
+  send_page_view: false,
+  linker: { domains: ${JSON.stringify(LINKER_DOMAINS)} }
+});
+`.trim();
+}
+
+function pushConsent(state) {
+  if (typeof window === 'undefined') return;
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push(['consent', 'update', state]);
+}
+
+export function hasAcceptedConsent() {
+  if (typeof document === 'undefined') return false;
+  return document.cookie.split('; ').indexOf(`${CONSENT_COOKIE_NAME}=true`) !== -1;
+}
+
+export function grantGoogleConsent() {
+  pushConsent(GRANTED_CONSENT);
+}
+
+export function denyGoogleConsent() {
+  pushConsent(DENIED_CONSENT);
+}
+
+let integrationsLoaded = false;
+
+export function resetConsentedIntegrationsForTest() {
+  integrationsLoaded = false;
+}
+
+/**
+ * Brevo and Partnero both write to the device with no denied mode to fall back
+ * on, so unlike the Google tag they are not loaded at all until consent.
+ *
+ * Idempotent because it runs from two places: the Accept click, and mount for
+ * a visitor who accepted on an earlier visit. react-cookie-consent fires
+ * `onAccept` only on the click itself, so without the mount path a returning
+ * visitor's stored consent was never honoured.
+ */
+export function loadConsentedIntegrations() {
+  if (typeof document === 'undefined' || integrationsLoaded) return;
+  integrationsLoaded = true;
+
+  const brevoScript = document.createElement('script');
+  brevoScript.src = 'https://cdn.brevo.com/js/sdk-loader.js';
+  brevoScript.async = true;
+  brevoScript.onload = () => {
+    window.Brevo = window.Brevo || [];
+    window.Brevo.push(['init', { client_key: BREVO_CLIENT_KEY }]);
+  };
+  document.head.appendChild(brevoScript);
+
+  // Partnero's queue stub has to exist before its script is appended, so calls
+  // made while it downloads are replayed rather than thrown away.
+  window.__partnerObject = 'po';
+  function partneroQueue() {
+    const call = { a: arguments, q: [] };
+    const pushed = this.push(call);
+    return typeof pushed !== 'number' ? pushed : partneroQueue.bind(call.q);
+  }
+  partneroQueue.q = partneroQueue.q || [];
+  window.po = window.po || partneroQueue.bind(partneroQueue.q);
+  window.po.q = window.po.q || partneroQueue.q;
+
+  const partneroScript = document.createElement('script');
+  partneroScript.src = `https://app.partnero.com/js/universal.js?v${~~(Date.now() / 1e6)}`;
+  partneroScript.async = true;
+  document.head.appendChild(partneroScript);
+
+  window.po('settings', 'assets_host', 'https://assets.partnero.com');
+  window.po('program', PARTNERO_PROGRAM_ID, 'load');
+}

--- a/src/utils/consent.test.js
+++ b/src/utils/consent.test.js
@@ -5,10 +5,11 @@ import {
   GRANTED_CONSENT,
   buildConsentBootstrapScript,
   hasAcceptedConsent,
+  readConsentChoice,
   grantGoogleConsent,
   denyGoogleConsent,
   loadConsentedIntegrations,
-  resetConsentedIntegrationsForTest,
+  revokeConsent,
 } from './consent';
 
 function clearCookies() {
@@ -117,26 +118,74 @@ describe('hasAcceptedConsent', () => {
   });
 });
 
+// The banner offers three outcomes, not two: a visitor who declined is in a
+// different position from one who has not answered yet, and only the first of
+// those needs a way back.
+describe('readConsentChoice', () => {
+  beforeEach(clearCookies);
+
+  it('reports an unanswered banner', () => {
+    expect(readConsentChoice()).toBe('unanswered');
+  });
+
+  it('reports an accept', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=true; path=/`;
+    expect(readConsentChoice()).toBe('accepted');
+  });
+
+  it('reports a decline', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=false; path=/`;
+    expect(readConsentChoice()).toBe('declined');
+  });
+
+  it('treats an unrecognised value as unanswered rather than guessing', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=maybe; path=/`;
+    expect(readConsentChoice()).toBe('unanswered');
+  });
+});
+
 describe('runtime consent updates', () => {
   beforeEach(() => {
     clearCookies();
     window.dataLayer = [];
   });
 
+  // gtag.js routes a dataLayer entry to its consent command table only when the
+  // entry is an `arguments` object; a plain array falls into the legacy
+  // method-call branch, throws, and is swallowed. Asserting the shape here is
+  // the only way to tell the two apart — `Array.from` normalises both.
+  it('pushes an arguments object, not an array, so gtag processes the command', () => {
+    grantGoogleConsent();
+
+    expect(Object.prototype.toString.call(window.dataLayer[0])).toBe('[object Arguments]');
+  });
+
+  // Asserted against literals rather than the exported constants, so flipping a
+  // value in consent.js cannot flip the expectation with it.
   it('grants every storage type on accept', () => {
     grantGoogleConsent();
     const call = Array.from(window.dataLayer[0]);
 
     expect(call[0]).toBe('consent');
     expect(call[1]).toBe('update');
-    expect(call[2]).toMatchObject(GRANTED_CONSENT);
+    expect(call[2]).toEqual({
+      ad_storage: 'granted',
+      ad_user_data: 'granted',
+      ad_personalization: 'granted',
+      analytics_storage: 'granted',
+    });
   });
 
   it('re-denies every storage type on reject', () => {
     denyGoogleConsent();
     const call = Array.from(window.dataLayer[0]);
 
-    expect(call[2]).toMatchObject(DENIED_CONSENT);
+    expect(call[2]).toEqual({
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'denied',
+    });
   });
 
   it('does not inject a second gtag loader on accept', () => {
@@ -147,12 +196,125 @@ describe('runtime consent updates', () => {
   });
 });
 
+describe('revokeConsent', () => {
+  beforeEach(() => {
+    clearCookies();
+    window.dataLayer = [];
+  });
+
+  it('clears the stored consent so the banner asks again', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=true; path=/`;
+    revokeConsent();
+
+    expect(hasAcceptedConsent()).toBe(false);
+  });
+
+  // Withdrawal that leaves the authorised cookies in place is not withdrawal.
+  it('expires the cookies the consent authorised, not just the answer', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=true; path=/`;
+    ['_gcl_au', 'sib_cuid', 'partnero_session_uuid'].forEach((name) => {
+      document.cookie = `${name}=whatever; path=/`;
+    });
+
+    revokeConsent();
+
+    ['_gcl_au', 'sib_cuid', 'partnero_session_uuid'].forEach((name) => {
+      expect(document.cookie.includes(`${name}=`)).toBe(false);
+    });
+  });
+
+  // Consent authorises storage, not just cookies — §25 TTDSG covers anything
+  // written to the device, so withdrawal has to reach localStorage too.
+  it('expires the device storage the consent authorised', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=true; path=/`;
+    ['_gcl_ls', '__wpfvdk', '_wpinitialpermissionstate'].forEach((key) => {
+      localStorage.setItem(key, 'whatever');
+    });
+
+    revokeConsent();
+
+    ['_gcl_ls', '__wpfvdk', '_wpinitialpermissionstate'].forEach((key) => {
+      expect(localStorage.getItem(key)).toBeNull();
+    });
+  });
+
+  it('leaves storage it did not authorise alone', () => {
+    localStorage.setItem('theme', 'dark');
+
+    revokeConsent();
+
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('is a safe no-op when nothing was ever stored', () => {
+    expect(() => revokeConsent()).not.toThrow();
+    expect(hasAcceptedConsent()).toBe(false);
+  });
+
+  it('is idempotent, so a double click does no harm', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=true; path=/`;
+    document.cookie = '_gcl_au=whatever; path=/';
+
+    revokeConsent();
+    revokeConsent();
+
+    expect(hasAcceptedConsent()).toBe(false);
+    expect(document.cookie.includes('_gcl_au=')).toBe(false);
+    const updates = window.dataLayer.map((a) => Array.from(a)).filter((c) => c[1] === 'update');
+    expect(updates.every((c) => c[2].ad_storage === 'denied')).toBe(true);
+  });
+
+  it('leaves cookies it did not authorise alone', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=true; path=/`;
+    document.cookie = 'docusaurus.theme=dark; path=/';
+
+    revokeConsent();
+
+    expect(document.cookie.includes('docusaurus.theme=dark')).toBe(true);
+  });
+
+  it('re-denies Google storage immediately rather than waiting for a reload', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=true; path=/`;
+    revokeConsent();
+    const call = Array.from(window.dataLayer[0]);
+
+    expect(call[1]).toBe('update');
+    expect(call[2].ad_storage).toBe('denied');
+  });
+});
+
+// The bootstrap runs in <head> before any bundle exists, so it cannot import
+// hasAcceptedConsent and has to repeat the cookie check by hand. Nothing else
+// stops the two copies drifting apart.
+describe('the two consent-cookie readers agree', () => {
+  beforeEach(clearCookies);
+
+  const cases = ['true', 'false', 'TRUE', 'True', '1', 'yes', ''];
+
+  cases.forEach((value) => {
+    it(`treats a \`${value}\` cookie the same in the bootstrap and at runtime`, () => {
+      document.cookie = `${CONSENT_COOKIE_NAME}=${value}; path=/`;
+      const grantedInBootstrap = runBootstrap().some(
+        (c) => c[0] === 'consent' && c[1] === 'update' && c[2].ad_storage === 'granted',
+      );
+
+      expect(grantedInBootstrap).toBe(hasAcceptedConsent());
+    });
+  });
+
+  it('only ever treats an exact "true" as consent', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=TRUE; path=/`;
+
+    expect(hasAcceptedConsent()).toBe(false);
+  });
+});
+
 describe('loadConsentedIntegrations', () => {
   beforeEach(() => {
     clearCookies();
     document.head.innerHTML = '';
     window.dataLayer = [];
-    resetConsentedIntegrationsForTest();
+    delete window.po;
   });
 
   it('loads Brevo and Partnero', () => {
@@ -171,5 +333,44 @@ describe('loadConsentedIntegrations', () => {
     );
 
     expect(brevo).toHaveLength(1);
+  });
+
+  // A hardened context can refuse the append. Marking the work done before it
+  // succeeds would strand the visitor with consent given and nothing loaded.
+  it('retries after a blocked append instead of latching permanently', () => {
+    const append = document.head.appendChild.bind(document.head);
+    const spy = vi
+      .spyOn(document.head, 'appendChild')
+      .mockImplementationOnce(() => {
+        throw new Error('blocked by content security policy');
+      });
+
+    expect(() => loadConsentedIntegrations()).toThrow();
+    spy.mockImplementation(append);
+    loadConsentedIntegrations();
+
+    const srcs = Array.from(document.querySelectorAll('script')).map((s) => s.src);
+    expect(srcs.some((s) => s.includes('brevo.com'))).toBe(true);
+    expect(srcs.some((s) => s.includes('partnero.com'))).toBe(true);
+    spy.mockRestore();
+  });
+
+  it('retries only the tag that failed when the first one already landed', () => {
+    const append = document.head.appendChild.bind(document.head);
+    let calls = 0;
+    const spy = vi.spyOn(document.head, 'appendChild').mockImplementation((node) => {
+      calls += 1;
+      if (calls === 2) throw new Error('blocked by content security policy');
+      return append(node);
+    });
+
+    expect(() => loadConsentedIntegrations()).toThrow();
+    spy.mockImplementation(append);
+    loadConsentedIntegrations();
+
+    const srcs = Array.from(document.querySelectorAll('script')).map((s) => s.src);
+    expect(srcs.filter((s) => s.includes('brevo.com'))).toHaveLength(1);
+    expect(srcs.filter((s) => s.includes('partnero.com'))).toHaveLength(1);
+    spy.mockRestore();
   });
 });

--- a/src/utils/consent.test.js
+++ b/src/utils/consent.test.js
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  CONSENT_COOKIE_NAME,
+  DENIED_CONSENT,
+  GRANTED_CONSENT,
+  buildConsentBootstrapScript,
+  hasAcceptedConsent,
+  grantGoogleConsent,
+  denyGoogleConsent,
+  loadConsentedIntegrations,
+  resetConsentedIntegrationsForTest,
+} from './consent';
+
+function clearCookies() {
+  document.cookie.split('; ').forEach((c) => {
+    const name = c.split('=')[0];
+    if (name) document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+  });
+}
+
+/**
+ * Run the head bootstrap the way the browser would: in a scope where `window`
+ * and `document` are the jsdom globals, with a fresh dataLayer.
+ */
+function runBootstrap() {
+  delete window.dataLayer;
+  // eslint-disable-next-line no-new-func
+  new Function('window', 'document', buildConsentBootstrapScript())(window, document);
+  return window.dataLayer.map((args) => Array.from(args));
+}
+
+describe('consent bootstrap script', () => {
+  beforeEach(clearCookies);
+
+  it('denies every storage type by default before anything else runs', () => {
+    const calls = runBootstrap();
+    const first = calls[0];
+
+    expect(first[0]).toBe('consent');
+    expect(first[1]).toBe('default');
+    expect(first[2]).toMatchObject(DENIED_CONSENT);
+  });
+
+  it('denies by default even when no consent cookie exists', () => {
+    const calls = runBootstrap();
+    const updates = calls.filter((c) => c[0] === 'consent' && c[1] === 'update');
+
+    expect(updates).toHaveLength(0);
+  });
+
+  it('keeps consent denied when the visitor previously clicked Reject', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=false; path=/`;
+    const calls = runBootstrap();
+    const updates = calls.filter((c) => c[0] === 'consent' && c[1] === 'update');
+
+    expect(updates).toHaveLength(0);
+  });
+
+  it('restores granted consent for a visitor who previously accepted', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=true; path=/`;
+    const calls = runBootstrap();
+    const update = calls.find((c) => c[0] === 'consent' && c[1] === 'update');
+
+    expect(update).toBeDefined();
+    expect(update[2]).toMatchObject(GRANTED_CONSENT);
+  });
+
+  it('is not fooled by a different cookie whose name ends with the consent name', () => {
+    document.cookie = `not_${CONSENT_COOKIE_NAME}=true; path=/`;
+    const calls = runBootstrap();
+    const updates = calls.filter((c) => c[0] === 'consent' && c[1] === 'update');
+
+    expect(updates).toHaveLength(0);
+  });
+
+  it('redacts ad identifiers and passes gclid through URLs while consent is denied', () => {
+    const calls = runBootstrap();
+    const sets = calls.filter((c) => c[0] === 'set');
+
+    expect(sets).toContainEqual(['set', 'ads_data_redaction', true]);
+    expect(sets).toContainEqual(['set', 'url_passthrough', true]);
+  });
+
+  it('configures the tag only after consent state is established', () => {
+    const calls = runBootstrap();
+    const defaultIndex = calls.findIndex((c) => c[0] === 'consent' && c[1] === 'default');
+    const configIndex = calls.findIndex((c) => c[0] === 'config');
+
+    expect(defaultIndex).toBeGreaterThanOrEqual(0);
+    expect(configIndex).toBeGreaterThan(defaultIndex);
+  });
+
+  it('keeps the cross-domain linker so gclid still reaches my.dawarich.app', () => {
+    const calls = runBootstrap();
+    const config = calls.find((c) => c[0] === 'config');
+
+    expect(config[2].send_page_view).toBe(false);
+    expect(config[2].linker.domains).toContain('my.dawarich.app');
+  });
+});
+
+describe('hasAcceptedConsent', () => {
+  beforeEach(clearCookies);
+
+  it('is false with no cookie', () => {
+    expect(hasAcceptedConsent()).toBe(false);
+  });
+
+  it('is false after a decline', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=false; path=/`;
+    expect(hasAcceptedConsent()).toBe(false);
+  });
+
+  it('is true after an accept', () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=true; path=/`;
+    expect(hasAcceptedConsent()).toBe(true);
+  });
+});
+
+describe('runtime consent updates', () => {
+  beforeEach(() => {
+    clearCookies();
+    window.dataLayer = [];
+  });
+
+  it('grants every storage type on accept', () => {
+    grantGoogleConsent();
+    const call = Array.from(window.dataLayer[0]);
+
+    expect(call[0]).toBe('consent');
+    expect(call[1]).toBe('update');
+    expect(call[2]).toMatchObject(GRANTED_CONSENT);
+  });
+
+  it('re-denies every storage type on reject', () => {
+    denyGoogleConsent();
+    const call = Array.from(window.dataLayer[0]);
+
+    expect(call[2]).toMatchObject(DENIED_CONSENT);
+  });
+
+  it('does not inject a second gtag loader on accept', () => {
+    grantGoogleConsent();
+    const loaders = document.querySelectorAll('script[src*="googletagmanager.com"]');
+
+    expect(loaders).toHaveLength(0);
+  });
+});
+
+describe('loadConsentedIntegrations', () => {
+  beforeEach(() => {
+    clearCookies();
+    document.head.innerHTML = '';
+    window.dataLayer = [];
+    resetConsentedIntegrationsForTest();
+  });
+
+  it('loads Brevo and Partnero', () => {
+    loadConsentedIntegrations();
+    const srcs = Array.from(document.querySelectorAll('script')).map((s) => s.src);
+
+    expect(srcs.some((s) => s.includes('brevo.com'))).toBe(true);
+    expect(srcs.some((s) => s.includes('partnero.com'))).toBe(true);
+  });
+
+  it('is idempotent so a returning visitor does not double-load them', () => {
+    loadConsentedIntegrations();
+    loadConsentedIntegrations();
+    const brevo = Array.from(document.querySelectorAll('script')).filter((s) =>
+      s.src.includes('brevo.com'),
+    );
+
+    expect(brevo).toHaveLength(1);
+  });
+});

--- a/src/utils/trackingConsentConfig.test.js
+++ b/src/utils/trackingConsentConfig.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import config from '@site/docusaurus.config.js';
+
+const scriptSrcs = config.scripts.map((s) => (typeof s === 'string' ? s : s.src));
+const headScripts = config.headTags
+  .filter((t) => t.tagName === 'script')
+  .map((t) => t.innerHTML || t.attributes?.src || '');
+
+/**
+ * Regression guard for cef12e7 (2026-04-27), which re-added an unconditional
+ * Google Ads loader to `scripts` four months after e9f3291 removed it. The
+ * commit was titled "Update timeline visualizer", so nothing in review
+ * signalled that a consent gate had been reopened.
+ */
+describe('no advertising tag may load outside the consent bootstrap', () => {
+  it('does not load Google Tag Manager from the unconditional scripts array', () => {
+    expect(scriptSrcs.filter((s) => s.includes('googletagmanager.com'))).toHaveLength(0);
+  });
+
+  it('does not configure a Google tag from the scripts array', () => {
+    expect(scriptSrcs.filter((s) => s.includes('gtag'))).toHaveLength(0);
+  });
+
+  it('loads the Google tag exactly once, from headTags', () => {
+    const loaders = headScripts.filter((s) => s.includes('googletagmanager.com/gtag/js'));
+
+    expect(loaders).toHaveLength(1);
+  });
+
+  it('establishes denied-by-default consent before the tag is configured', () => {
+    const bootstrap = headScripts.find((s) => s.includes("gtag('consent', 'default'"));
+
+    expect(bootstrap).toBeDefined();
+    expect(bootstrap.indexOf("'default'")).toBeLessThan(bootstrap.indexOf("gtag('config'"));
+
+    // Normalised so the assertion survives a change of quoting or spacing in
+    // how the defaults are serialised; the runtime meaning is asserted by
+    // executing the script in consent.test.js.
+    const normalised = bootstrap.replace(/["'\s]/g, '');
+    ['ad_storage', 'ad_user_data', 'ad_personalization', 'analytics_storage'].forEach((key) => {
+      expect(normalised).toContain(`${key}:denied`);
+    });
+  });
+
+  it('emits the consent bootstrap before the tag loader in document order', () => {
+    const order = config.headTags
+      .filter((t) => t.tagName === 'script')
+      .map((t) =>
+        (t.innerHTML || '').includes("gtag('consent', 'default'")
+          ? 'bootstrap'
+          : (t.attributes?.src || '').includes('googletagmanager.com')
+            ? 'loader'
+            : 'other',
+      );
+
+    expect(order.indexOf('bootstrap')).toBeGreaterThanOrEqual(0);
+    expect(order.indexOf('bootstrap')).toBeLessThan(order.indexOf('loader'));
+  });
+
+  it('still loads the cookieless analytics that need no consent', () => {
+    expect(scriptSrcs.some((s) => s.includes('simpleanalyticscdn.com'))).toBe(true);
+    expect(scriptSrcs.some((s) => s.includes('rybbit'))).toBe(true);
+  });
+});

--- a/src/utils/trackingConsentConfig.test.js
+++ b/src/utils/trackingConsentConfig.test.js
@@ -1,3 +1,5 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, it, expect } from 'vitest';
 import config from '@site/docusaurus.config.js';
 
@@ -57,8 +59,39 @@ describe('no advertising tag may load outside the consent bootstrap', () => {
     expect(order.indexOf('bootstrap')).toBeLessThan(order.indexOf('loader'));
   });
 
-  it('still loads the cookieless analytics that need no consent', () => {
+  it('still loads the analytics that are not gated behind the banner', () => {
     expect(scriptSrcs.some((s) => s.includes('simpleanalyticscdn.com'))).toBe(true);
     expect(scriptSrcs.some((s) => s.includes('rybbit'))).toBe(true);
+  });
+});
+
+// The Google tag loads on every page and is held back by Consent Mode, not by
+// the banner. Three separate pages used to say it only fires once you accept;
+// two of them were fixed in this change and the third was found by review.
+describe('no page claims the ad tag is withheld until consent', () => {
+  const STALE_CLAIMS = [
+    'only fire if you accept',
+    'fires only if you accept',
+    'only load if you click',
+    'only loads if you accept',
+  ];
+
+  function sourceFiles(dir) {
+    return readdirSync(dir).flatMap((entry) => {
+      const path = join(dir, entry);
+      if (statSync(path).isDirectory()) return sourceFiles(path);
+      return /\.(js|jsx|md|mdx)$/.test(entry) && !/\.test\./.test(entry) ? [path] : [];
+    });
+  }
+
+  // Matched against whitespace-collapsed source, because JSX wraps prose across
+  // lines and tabs — the same sentence would otherwise slip past on a reflow.
+  it('says nowhere in src/ that the tag waits for the banner', () => {
+    const offenders = sourceFiles('src').filter((path) => {
+      const text = readFileSync(path, 'utf8').replace(/\s+/g, ' ');
+      return STALE_CLAIMS.some((claim) => text.includes(claim));
+    });
+
+    expect(offenders).toEqual([]);
   });
 });

--- a/src/utils/utm.js
+++ b/src/utils/utm.js
@@ -18,6 +18,8 @@
  * PartneroJS on the app re-read it from the URL and set its own cookie there.
  */
 
+import { hasAcceptedConsent } from './consent';
+
 const UTM_PARAMS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content'];
 const STORAGE_KEY = 'original_utm_params';
 const STORAGE_DURATION = 30 * 24 * 60 * 60 * 1000; // 30 days in milliseconds
@@ -32,7 +34,6 @@ const REFERRAL_PARAMS = ['aff', 'via'];
 // Set by the cookie banner (src/components/CookieConsent.js). The affiliate key
 // is not strictly necessary under § 25 TTDSG, and both the banner and the privacy
 // policy tell visitors it is only stored if they accept — so the code has to ask.
-const CONSENT_COOKIE = 'dawarichCookieConsent';
 const REFERRAL_STORAGE_KEY = 'partnero_referral';
 // Keep at or above the cookie lifetime configured in the Partnero program, otherwise
 // the site stops forwarding a key that Partnero would still have honoured.
@@ -84,14 +85,11 @@ export function saveOriginalUtmParams() {
  * Whether the visitor accepted the cookie banner.
  *
  * An unanswered banner is not consent, so anything but an explicit "true" means no.
+ * The cookie itself is read by src/utils/consent.js, which owns the banner's
+ * name and the gating of every tag that writes to the device.
  */
 export function hasTrackingConsent() {
-  if (typeof document === 'undefined') return false;
-
-  return document.cookie
-    .split(';')
-    .map((entry) => entry.trim())
-    .some((entry) => entry === `${CONSENT_COOKIE}=true`);
+  return hasAcceptedConsent();
 }
 
 /**


### PR DESCRIPTION
## Problem

The Google Ads tag is loaded from the `scripts` array in `docusaurus.config.js`, so it is a hardcoded `<script>` in the `<head>` of every built page. `gtag.js` therefore runs and sets `_gcl_au` on first paint — before the cookie banner renders, and it stays set after the visitor clicks **Reject**.

That contradicts what we tell people in three places:

| Claim | Where | Reality |
|---|---|---|
| "these only load if you click Accept" | `CookieConsent.js` banner copy | already loaded |
| "Google Ads — consent-based" | `privacy-policy.md` processor table | not consent-based |
| Advertising → Consent **Yes** | `privacy-policy.md` cookie table | no consent taken |

This is a regression, not an original decision. `e9f3291` (2026-01-23, *"Load google code conditionally"*) removed the tag and moved it behind the banner. `cef12e7` (2026-04-27, *"Update timeline visualizer"*) put it back, because removing it had broken the cross-domain linker that carries `gclid` across to `my.dawarich.app`. Nothing in that commit's title signalled that a consent gate had been reopened, so it survived four months.

## Approach

Consent Mode v2 dissolves the consent-vs-attribution trade-off that caused the revert.

The tag still loads on every page, so the linker keeps working. It just loads **denied**: `ad_storage`, `ad_user_data`, `ad_personalization` and `analytics_storage` are all `denied` by default, so it writes nothing to the device until the visitor accepts. `url_passthrough` carries the `gclid` on the URL instead of in a cookie, so click attribution survives for everyone who never accepts — strictly better than the January fix, which killed the linker outright.

## Two related bugs fixed alongside

1. **Double loader.** Accept appended a second `gtag.js` on top of the one already in the head. It now flips consent on the existing tag.
2. **Returning visitors got nothing.** `react-cookie-consent` fires `onAccept` only on the click itself, never on mount (`componentDidMount` only sets `visible`). A visitor who accepted last month loaded neither Brevo nor Partnero — the cookie was written and then never read. Consent is now re-applied on mount, and synchronously in the head for the Google tag.

## Changes

- **`src/utils/consent.js`** (new) — single owner of the consent cookie and of every tag that writes to a device. Also builds the inline head bootstrap, so the config holds no tracking logic.
- **`docusaurus.config.js`** — Google Ads removed from the unconditional `scripts` array; `headTags` emits the consent bootstrap *then* the loader, in that order.
- **`src/components/CookieConsent.js`** — Accept flips consent instead of injecting a loader; mount effect honours stored consent; Reject explicitly re-denies.
- **`src/utils/utm.js`** — its private `hasTrackingConsent` cookie reader now delegates to `consent.js`; the duplicated cookie name is gone.
- **`src/pages/privacy-policy.md`** — documents the denied-by-default state, adds Rybbit to the cookieless row, changelog row and effective date.

## Verification

Built both versions and compared in a browser against the served build:

| | before | after |
|---|---|---|
| consent signals in `dataLayer` | `[]` | `default → all denied` |
| `_gcl_au` before touching banner | **present** | **absent** |
| after Reject | — | stays denied, no ad cookie |
| after Accept | — | `update → granted`, Brevo + Partnero load |
| gtag loaders on the page | 2 after accept | 1 always |
| returning visitor, no click | Brevo/Partnero never loaded | granted in head, tags load |

The Brevo (`sib_cuid`) and Partnero cookies appearing only after Accept are the positive control — they show the check can actually observe third-party cookie writes, so "no `_gcl_au`" is not a false negative.

## Tests

28 new tests; 313 pass across 36 files. The two regression guards are mutation-tested rather than assumed:

- re-adding the exact `cef12e7` line to `scripts` → 2 tests fail
- removing the mount effect → returning-visitor test fails
- removing `grantGoogleConsent()` → Accept test fails

`src/utils/trackingConsentConfig.test.js` asserts against the real config object, so any future reintroduction of an unconditional advertising loader fails CI. It carries a comment naming `cef12e7` and why review missed it.

## Not in scope

`dawarich` and `manager` both still have no consent mechanism at all — the Rails layouts load gtag, Partnero and Paddle unconditionally, and the Devise sign-in pages carry them. `consent.js` gives a shape to port when we want it.
