### PR TITLE
docs: rewrite mobile app guides for the current apps

### DIFF
--- a/docs/dawarich-for-android.md
+++ b/docs/dawarich-for-android.md
@@ -1,35 +1,163 @@
 ---
 sidebar_position: 98
 title: Dawarich for Android
-description: Install and set up the Dawarich Android app for location tracking on Android devices.
+description: Install the Dawarich Android app, connect it to Dawarich Cloud or your self-hosted instance, grant location permissions, and tune tracking and upload settings.
 ---
 
 # Dawarich for Android
 
-Dawarich is available on Android. You can download it from Google Play.
+The Dawarich app records your location on your Android phone or tablet and uploads it to Dawarich Cloud or to your own self-hosted instance. It keeps recording in the background and works offline.
+
+**Requirements:** an Android phone or tablet, and either a Dawarich Cloud account or a self-hosted Dawarich instance.
 
 ## Installation
 
-1. Open Google Play.
-2. Search for "Dawarich".
-3. Tap "Install" and follow the instructions to install the app.
+Search for "Dawarich" in Google Play, or tap the badge below.
 
 <a href="https://play.google.com/store/apps/details?id=app.dawarich.Dawarich">
-  <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" style={{width: "250px"}} />
+  <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" width="220" />
 </a>
 
-## Usage
+## Connect to a server
 
-1. Open the app.
-2. Open Settings.
-3. Provide your Dawarich instance URL.
-4. Provide your Dawarich API key.
-5. Tap "Test connection". You should see a message that the connection is successful.
-6. Open Map page.
-7. Tap "Start tracking".
-8. Move around and see your location on the map.
-9. To upload your location to Dawarich, tap "Stop tracking" and then "Upload points".
+On first launch the app shows a short intro, then the sign-in screen.
+
+### Dawarich Cloud
+
+Tap **Sign in with Google** or **Sign up with Email**. If you already have a Cloud account, tap **Already have an account? Sign in**.
+
+### Self-hosted instance
+
+Tap **For self-hosters — Connect to your own Dawarich instance**, then pick one of two methods:
+
+- **Scan QR Code** — open your Dawarich instance in a browser, go to **Account → API access**, and scan the QR code shown there. The server URL and API key are filled in and validated for you.
+- **Manual Setup** — enter your **Server URL** (for example `https://your-server.example.com`) and the **API key** from the same **Account → API access** page. If your server sits behind an authenticating reverse proxy such as Pangolin or Cloudflare Access, add the required **Custom headers** here; they are stored per server and are never sent to Dawarich Cloud.
+
+:::tip
+Use HTTPS. The app warns you when the URL is plain HTTP.
+:::
+
+You can also tap **Continue without signing in** to look around first. Nothing is uploaded until you connect a server — do that later from **Settings → Server Connection → Sign in**.
+
+## Grant permissions
+
+After connecting, the app walks you through the permissions it needs. Getting these right is what makes tracking reliable on Android.
+
+1. **Location data** — choose **"While using the app"** and leave **Precise Location** on, so your journeys come out accurate.
+2. **Always-on tracking** — set location access to **"Allow all the time"**. Without it, tracking stops the moment you leave the app.
+3. **Tracking notification** (Android 13 and newer) — Dawarich shows a quiet, ongoing notification while it tracks. That notification is how Android knows to keep recording in the background, so leave it enabled.
+4. **Keep Dawarich running** — swiping Dawarich out of **Recent Apps** can stop tracking, and many phones close background apps to save battery.
+
+You can review the current state and re-request anything later under **Settings → App → Permissions**.
+
+:::caution Battery optimisation
+For reliable recording, set battery usage to **Unrestricted** under **Settings → Apps → Dawarich → Battery**. On Samsung, Xiaomi, Huawei and OnePlus devices, also enable **Auto-start**. See [dontkillmyapp.com](https://dontkillmyapp.com) for the settings your specific phone needs.
+
+On Android 14 and newer, you can dismiss the ongoing tracking notification without stopping tracking — it stays dismissed for the rest of that tracking session.
+:::
+
+## Start tracking
+
+1. Open the **Map** tab.
+2. Expand the tracking card at the bottom of the screen.
+3. Turn **Tracking** on.
+
+The card shows the time of the last sync and the current upload mode, and switches to a **Synced** state once your points have reached the server.
+
+To have tracking resume by itself, turn on **Start tracking automatically** under **Settings → Tracking → Tracking Settings** — tracking then starts whenever you launch the app.
+
+## Uploading points
+
+By default the app uploads points automatically while tracking, so there is nothing to do manually. The behaviour is configurable under **Settings → Upload**:
+
+| Setting | What it does |
+|---|---|
+| **Upload points automatically** | Uploads while tracking. On by default. |
+| **Upload when tracking stops** | Uploads all pending points when you turn tracking off. |
+| **Batch size** | How many points each automatic upload sends. Default 100. |
+| **Re-upload points** | Re-sends the points recorded in a date range you pick. |
+
+You can also upload on demand: tap the sync button on the tracking card to upload pending points and refresh the selected history.
+
+If an upload fails, an **Upload failed** banner appears on the map with a **Retry** action.
 
 ## Offline tracking
 
 The app records your location on your device, so tracking keeps working even without an internet connection — on a plane, underground, hiking off-grid, or travelling abroad without data. Your points are stored safely on the phone and uploaded to your Dawarich instance automatically once you're back online. Nothing is lost to a dropped connection.
+
+## Tracking settings
+
+**Settings → Tracking → Tracking Settings**
+
+### Smart Tracking (experimental)
+
+Smart Tracking uses motion detection to pause location updates after you have been still for a while and resume them once you move again or leave the area. Two settings control it:
+
+- **Stationary Duration** — how long still motion must continue before tracking pauses.
+- **Geofence Radius** — the radius used to resume tracking after leaving the stationary area.
+
+An event log below the settings shows when it paused and resumed.
+
+:::caution Experimental
+Smart Tracking may not pause or resume reliably. Tracking might remain active, stop unexpectedly, or fail to record some locations. Leave it off if you need complete tracks.
+:::
+
+### Fine-tuning
+
+- **Accuracy** — higher accuracy uses more battery.
+- **Distance Filter** — record a new location only if the device has moved at least this distance.
+- **Time Filter** — record a new location only if at least this much time has passed since the last one.
+- **Track Breaking** — start a new track if no location is received within this interval.
+
+## On the map
+
+- **Day ribbon** — horizontal day cards with per-day point density, an hourly sparkline for the selected day, and a jump-to-date modal for picking a day or a multi-day range.
+- **Layers** — toggle routes, points and the heatmap. **Points source** switches between **Server + device** and **Device only**.
+- **Replay** — play back the selected day's movement from the timeline controls.
+
+## Insights
+
+The **Insights** tab has three sub-tabs:
+
+- **Insights** — year totals, year-over-year comparison, an activity heatmap, streaks and travel patterns.
+- **Stats** — per-year stats with a monthly distance chart.
+- **Digests** — browse, generate and delete yearly digests.
+
+All of it is cached on device, so it still opens when you're offline.
+
+## Sync settings between devices
+
+Once connected, **Settings → Settings sync** stores your tracking and upload preferences on your Dawarich server so your devices match. The **Status** row tells you whether settings are synced, pending, unsupported by your server, or failing, and **Sync now** retries and re-checks server support. A per-device switch lets one device keep its settings local.
+
+Servers that are too old for the mobile settings API simply keep settings on the device.
+
+Under **Settings → Preferences** you can switch the distance unit between kilometres and miles; the change applies across Stats, Insights and Digests immediately, including offline.
+
+## Automation
+
+### Quick Settings tiles
+
+Dawarich provides two Quick Settings controls:
+
+- **Dawarich tracking** — toggles location tracking and reflects its current state.
+- **Upload points** — schedules all pending points for upload.
+
+Open Quick Settings, enter edit mode, and drag either control into the active area. The device must be unlocked before either one runs, and **Upload points** stays dimmed until a server URL and API key are saved.
+
+### Tasker and other automation apps
+
+Dawarich exposes three Locale/Tasker plug-in actions — **Start tracking**, **Stop tracking** and **Upload track** — which also work with compatible hosts such as MacroDroid and Automate.
+
+They are **off by default**. Turn on **Allow other apps to trigger Dawarich** under **Settings → Android automation** first; until you do, every action returns an error and changes nothing.
+
+:::caution
+Once the opt-in is on, any installed app can invoke these actions — the caller is not limited to Tasker. That is a consequence of the Locale plug-in protocol, which requires an exported receiver that no app-specific permission can restrict.
+:::
+
+## Troubleshooting
+
+**Tracking stops when the app is in the background.** Check that location access is set to **Allow all the time** in **Settings → App → Permissions**, set battery usage to **Unrestricted**, and don't swipe Dawarich out of Recent Apps. See [dontkillmyapp.com](https://dontkillmyapp.com) for manufacturer-specific settings.
+
+**Points aren't reaching the server.** Open **Settings → Server Connection** and tap **Test Connection**. It shows the server URL and, when the connection succeeds, the server version. If you are behind a reverse proxy, check your custom headers under **Self-hosted settings**.
+
+**Something else is wrong.** **Settings → Debug → Debug logs** collects logs you can share with the developers. Alerts about tracking, uploads and visits can be turned on or off individually under **Settings → Notifications → Notification settings**.

--- a/docs/dawarich-for-ios.md
+++ b/docs/dawarich-for-ios.md
@@ -1,39 +1,154 @@
 ---
 sidebar_position: 97
 title: Dawarich for iOS
-description: Install and set up the Dawarich iOS app for location tracking on iPhone and iPad.
+description: Install the Dawarich iOS app, connect it to Dawarich Cloud or your self-hosted instance, grant location permissions, and tune tracking and upload settings.
 ---
 
 # Dawarich for iOS
 
-Dawarich is available on iOS. You can download it from the App Store.
+The Dawarich app records your location on your iPhone or iPad and uploads it to Dawarich Cloud or to your own self-hosted instance. It keeps recording in the background and works offline.
+
+**Requirements:** iOS 17.6 or later, and either a Dawarich Cloud account or a self-hosted Dawarich instance.
 
 ## Installation
 
-1. Open the App Store.
-2. Search for "Dawarich".
-3. Tap "Install" and follow the instructions to install the app.
+Search for "Dawarich" in the App Store, or tap the badge below.
 
-import ThemedImage from '@theme/ThemedImage';
-
-import useBaseUrl from '@docusaurus/useBaseUrl';
-
-<a href="https://apps.apple.com/app/apple-store/id6739544999?pt=128010810&ct=landing-navbar&mt=8">
-  <img src={useBaseUrl("img/dawarich-release-announcement.png")} alt="Download on the App Store" style={{width: "75%"}} />
+<a href="https://apps.apple.com/app/apple-store/id6739544999?pt=128010810&ct=docs-ios&mt=8">
+  <img src="/img/app-store.png" alt="Download on the App Store" width="220" />
 </a>
 
-## Usage
+## Connect to a server
 
-1. Open the app.
-2. Open Settings
-3. Provide your Dawarich instance URL
-4. Provide your Dawarich API key
-5. Tap "Test connection". You should see a message that the connection is successful.
-6. Open Map page.
-7. Tap "Start tracking".
-8. Move around and see your location on the map.
-9. To upload your location to Dawarich, tap "Stop tracking" and then "Upload points".
+On first launch the app shows a short intro, then the sign-in screen.
+
+### Dawarich Cloud
+
+Tap **Sign in with Apple**, **Sign in with Google**, or **Sign up with Email**. If you already have a Cloud account, tap **Already have an account? Sign in**.
+
+### Self-hosted instance
+
+Tap **For self-hosters — Connect to your own Dawarich instance**, then pick one of two methods:
+
+- **Scan QR Code** — open your Dawarich instance in a browser, go to **Account → API access**, and scan the QR code shown there. The server URL and API key are filled in and validated for you.
+- **Manual Setup** — enter your **Server URL** (for example `https://your-server.example.com`) and the **API key** from the same **Account → API access** page. If your server sits behind an authenticating reverse proxy such as Pangolin or Cloudflare Access, add the required **Custom headers** here; they are stored per server and are never sent to Dawarich Cloud.
+
+:::tip
+Use HTTPS. The app warns you when the URL is plain HTTP. If your server is on your local network, iOS asks for local network access the first time you connect.
+:::
+
+You can also tap **Continue without signing in** to look around first. Nothing is uploaded until you connect a server — do that later from **Settings → Server Connection → Sign in**.
+
+## Grant permissions
+
+After connecting, the app walks you through the permissions it needs. Getting these right is what makes tracking reliable.
+
+1. **Location data** — choose **"While Using the App"** and leave **Precise Location** on, so your journeys come out accurate.
+2. **Always-on tracking** — set location access to **"Always Allow"**. Without it, tracking stops the moment you leave the app.
+3. **Don't swipe Dawarich away** — swiping the app up and off the app switcher fully closes it, and no points are recorded until you open it again. You don't need to keep Dawarich on screen; just leave it running in the background.
+
+You can review the current state and re-request anything later under **Settings → App → Permissions**.
+
+## Start tracking
+
+1. Open the **Map** tab.
+2. Expand the tracking card at the bottom of the screen.
+3. Turn **Tracking** on.
+
+The card shows the time of the last sync and the current upload mode, and switches to a **Synced** state once your points have reached the server.
+
+To have tracking resume by itself, turn on **Start tracking automatically** under **Settings → Tracking → Tracking Settings** — tracking then starts whenever you launch the app.
+
+## Uploading points
+
+By default the app uploads points automatically while tracking, so there is nothing to do manually. The behaviour is configurable under **Settings → Upload**:
+
+| Setting | What it does |
+|---|---|
+| **Upload points automatically** | Uploads while tracking. On by default. |
+| **Upload when tracking stops** | Uploads all pending points when you turn tracking off. |
+| **Batch size** | How many points each automatic upload sends. Default 100. |
+| **Re-upload points** | Re-sends the points recorded in a date range you pick. |
+
+You can also upload on demand: tap the sync button on the tracking card to upload pending points and refresh the selected history.
+
+If an upload fails, an **Upload failed** banner appears on the map with a **Retry** action.
 
 ## Offline tracking
 
 The app records your location on your device, so tracking keeps working even without an internet connection — on a plane, underground, hiking off-grid, or travelling abroad without data. Your points are stored safely on the iPhone and uploaded to your Dawarich instance automatically once you're back online. Nothing is lost to a dropped connection.
+
+## Tracking settings
+
+**Settings → Tracking → Tracking Settings**
+
+### Detail level
+
+- **Detailed** — records a more detailed path using your accuracy, distance and time settings. Higher battery use.
+- **Battery saver** — lets iOS report significant movement only. Minimal battery use.
+
+Switching modes while you are recording ends the current track and starts a new one.
+
+### Continuous Tracking
+
+Available in **Detailed** mode. Keeps tracking enabled with iOS-managed, motion-aware location updates: iOS pauses updates to conserve battery and resumes them when it detects movement. While it is on, iOS manages the distance filter and the blue background location indicator is always shown.
+
+### Fine-tuning
+
+In **Detailed** mode you can tune how often a point is recorded:
+
+- **Accuracy** — higher accuracy uses more battery.
+- **Distance Filter** — record a new location only if the device has moved at least this distance.
+- **Time Filter** — record a new location only if at least this much time has passed since the last one.
+- **Track Breaking** — start a new track if no location is received within this interval.
+- **Show location indicator** — shows the blue iOS background location indicator while tracking.
+
+Battery saver mode ignores these — iOS decides when to report a location.
+
+### Visits
+
+Choose how visits are detected:
+
+- **While tracking** (default) — detect visits only while location tracking is on.
+- **Always on** — detect visits even when tracking is off.
+- **Off** — don't detect visits.
+
+## On the map
+
+- **Day ribbon** — horizontal day cards with per-day point density, an hourly sparkline for the selected day, and a jump-to-date modal for picking a day or a multi-day range.
+- **Layers** — toggle routes, visits, points and the heatmap. **Points source** switches between **Server + device** and **Device only**.
+- **Replay** — play back the selected day's movement from the timeline controls.
+
+## Insights
+
+The **Insights** tab has three sub-tabs:
+
+- **Insights** — year totals, year-over-year comparison, an activity heatmap, streaks and travel patterns.
+- **Stats** — per-year stats with a monthly distance chart.
+- **Digests** — browse, generate and delete yearly digests.
+
+All of it is cached on device, so it still opens when you're offline.
+
+## Sync settings between devices
+
+Once connected, **Settings → Settings sync** stores your tracking and upload preferences on your Dawarich server so your devices match. The **Status** row tells you whether settings are synced, pending, unsupported by your server, or failing, and **Sync now** retries and re-checks server support. A per-device switch lets one device keep its settings local.
+
+Servers that are too old for the mobile settings API simply keep settings on the device.
+
+Under **Settings → Preferences** you can switch the distance unit between kilometres and miles; the change applies across Stats, Insights and Digests immediately, including offline.
+
+## Pro features
+
+**Import from Apple Health** reads workouts that carry a route from Apple Health and imports them into Dawarich. It is part of the Pro subscription — tap **Subscribe to Pro** under **Settings → Pro features** if you don't have it yet.
+
+## Automation
+
+The app exposes **Start Tracking**, **Stop Tracking** and **Upload Points** actions to the Shortcuts app, so you can trigger them from time- or location-based automations. See [Tracking with Shortcuts](/docs/getting-started/ios-app/shortcuts-automation).
+
+## Troubleshooting
+
+**Tracking stops when the app is in the background.** Check that location access is set to **Always Allow** in **Settings → App → Permissions**, and make sure you are not swiping Dawarich out of the app switcher.
+
+**Points aren't reaching the server.** Open **Settings → Server Connection** and tap **Test Connection**. It shows the server URL and, when the connection succeeds, the server version. If you are behind a reverse proxy, check your custom headers under **Self-hosted settings**.
+
+**Something else is wrong.** **Settings → Debug → Debug logs** collects logs you can share with the developers. Alerts about tracking, uploads and visits can be turned on or off individually under **Settings → Notifications → Notification settings**.

--- a/docs/getting-started/track-your-location.md
+++ b/docs/getting-started/track-your-location.md
@@ -6,30 +6,27 @@ description: Set up location tracking using the Dawarich app, Overland, OwnTrack
 
 # Track your location
 
-Dawarich allows you to track your location using [Overland](https://overland.p3k.app/), [OwnTracks](https://owntracks.org/), [Traccar Client](https://www.traccar.org/client/) or [GPSLogger](https://gpslogger.app/) mobile application.
+The easiest way to track your location is the official Dawarich app for [iOS](/docs/dawarich-for-ios) and [Android](/docs/dawarich-for-android). If you'd rather use a third-party tracker, Dawarich also accepts data from [Overland](https://overland.p3k.app/), [OwnTracks](https://owntracks.org/), [Traccar Client](https://www.traccar.org/client/) and [GPSLogger](https://gpslogger.app/).
 
 ## API
 
 Dawarich provides an API for tracking your location. You can use the API to send your location data to Dawarich. Overland and OwnTracks are supposed to send their data to appropriate endpoints. You can find the API documentation at `/api-docs` endpoint of your Dawarich instance, and you can find the API key in the *Account* section.
 
-## Dawarich iOS
+## Dawarich app
 
-1. Install the Dawarich iOS app on your mobile device.
-2. Open the app and go to the settings.
-3. Set your API key.
-4. Tap on the "Save" button.
-5. You're all set! Dawarich will start tracking your location.
+The official app records your location in the background, keeps working offline, and uploads points automatically once it's online again.
 
-## Dawarich Android
+1. Install the app from the [App Store](/docs/dawarich-for-ios) or [Google Play](/docs/dawarich-for-android).
+2. Sign in to Dawarich Cloud, or tap **For self-hosters** and connect to your own instance by scanning the QR code on your **Account → API access** page, or by entering the server URL and API key manually.
+3. Complete the permissions walkthrough — background location access is what keeps tracking alive when the app isn't on screen.
+4. Open the **Map** tab and turn **Tracking** on.
 
-### Official
-1. Install the Dawarich Android app on your mobile device.
-2. Open the app and go to the settings.
-3. Set your server URL and API key.
-4. Tap on the "Save" button.
-5. You're all set! Dawarich will start tracking your location.
+Full setup, tracking and upload options are covered in [Dawarich for iOS](/docs/dawarich-for-ios) and [Dawarich for Android](/docs/dawarich-for-android).
 
-### Community
+## Dawarich Android (community app)
+
+An independent, community-built Android client.
+
 1. Install the Dawarich Community app on your mobile device.
    Download:
    - [GitHub Releases](https://github.com/sunstep/dawarich-android/releases)


### PR DESCRIPTION
## Why

`docs/dawarich-for-ios.md` and `docs/dawarich-for-android.md` still described the pre-2.x apps:

> Open Settings → provide instance URL → provide API key → Test connection → Start tracking → **Stop tracking** → **Upload points**

None of that is how the shipped apps work. There is no manual "Upload points" step in the normal flow, self-hosters connect by scanning a QR code, and Cloud users sign in with Apple/Google/email. Everything added since — permissions onboarding, tracking modes, Smart/Continuous Tracking, visits, upload settings, settings sync, Insights, Quick Settings tiles, the Tasker opt-in — was undocumented.

## What changed

Both platform pages were rewritten against the app source (`multiplatform-app` @ `main`, 2.6/129) so every label in the docs matches a label in the app:

- Requirements, install, and connecting to Dawarich Cloud **or** a self-hosted instance — QR code from **Account → API access**, or manual server URL + API key, including custom headers for Pangolin / Cloudflare Access.
- The permissions walkthrough, written as the app words it, since this is what makes background tracking actually survive.
- Starting tracking, and the **Settings → Upload** options (automatic uploads, upload on stop, batch size, re-upload, retry banner).
- Tracking settings, split by what each platform really has: Detailed / Battery saver, Continuous Tracking, fine-tuning, visits modes and Apple Health on iOS; Smart Tracking with its experimental warning, battery optimisation and `dontkillmyapp.com` on Android.
- Map layers and replay, the Insights tab, settings sync and the distance unit, automation, troubleshooting.
- Offline tracking is kept as-is.

**Track your location** had two more stale copies of the old instructions; they are now one short "Dawarich app" section that links to the platform pages, with the community Android client kept as its own section. The intro now leads with the official apps instead of listing only third-party trackers.

The App Store link on the iOS page carried `ct=landing-navbar`, so docs traffic was being reported under the landing page navbar campaign. It is now `ct=docs-ios`.

## Verified

- Dev server compiles both pages with no MDX errors; all three pages and every internal link render 200.
- Checked at 1440px and 390px — no horizontal page scroll, tables and admonitions render.
- iOS minimum version (17.6) confirmed against the live App Store listing rather than the Xcode project.

## Note

I deliberately did not state a minimum Android version. The repo's `minSdk` is 24, but I could not confirm what Google Play actually reports, and a wrong number on this page is worse than none. Happy to add it if you know the right value.
